### PR TITLE
feat!: update minimum Python version from 3.6 to 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The linter sends the Jenkinsfile to your Jenkins instance's `/pipeline-model-con
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.10+
 - Jenkins server with Pipeline plugin installed
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A Jenkinsfile linter that validates Jenkinsfiles using Jenkins API"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The CI only tests Python 3.8 through 3.14, so the requires-python = ">=3.6" declaration is misleading — it claims support for 3.6 and 3.7 which are never tested. Bumping to >=3.10 aligns the metadata with the CI matrix and avoids false trust from users on untested versions.