### PR TITLE
docs: add Security Notes section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Then install the pre-commit hook:
 pre-commit install
 ```
 
+## Security Notes
+
+- Do not commit Jenkins tokens to `.pre-commit-config.yaml`.
+- Prefer environment variables or local secret managers.
+- Avoid using administrator tokens for local linting.
+
 ## How It Works
 
 The linter sends the Jenkinsfile to your Jenkins instance's `/pipeline-model-converter/validate` endpoint for validation. Jenkins credentials (URL, username, and API token) are required.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ pre-commit install
 
 ## Security Notes
 
-- Do not commit Jenkins tokens to `.pre-commit-config.yaml`.
+- Do not commit Jenkins tokens to `.pre-commit-config.yaml` or `.env` .
 - Prefer environment variables or local secret managers.
 - Avoid using administrator tokens for local linting.
 


### PR DESCRIPTION
## Summary

Add a dedicated **Security Notes** section to the README to provide clear security guidance for enterprise users.

The new section includes:
- Do not commit Jenkins tokens to `.pre-commit-config.yaml`.
- Prefer environment variables or local secret managers.
- Avoid using administrator tokens for local linting.

Since this tool inherently involves Jenkins credentials, making security best practices explicit helps enterprise users adopt it more confidently.