### PR TITLE
feat: add --format json and --format github output options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Valid files produce no output. This format is ideal for:
 - **Jenkins pipeline self-validation** — parseable by pipeline scripts
 - **External validators** (ODS[^1], custom CI systems) — structured, machine-friendly output
 
-[^1]: [Open Delivery Stack](https://github.com/opendeliverystack) — an open-source CI/CD framework for automated software delivery.
+[^1]: [Open Delivery Stack](https://github.com/open-delivery-spec) — an open-source CI/CD framework for automated software delivery.
 
 ### Pre-commit Hook
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Catch Jenkinsfile syntax errors before they break your CI.
 - Supports both command-line usage and environment variables for configuration
 - Requires Jenkins credentials for validation
 - Supports skipping files that are not Jenkins pipelines (e.g., pure Groovy helper classes)
+- Machine-readable JSON and GitHub Actions annotation output for CI/CD integration
 
 ## Installation
 
@@ -113,6 +114,47 @@ jenkinsfilelint --include 'Jenkinsfile*' --include 'pipelines/*.groovy' \
 ```
 
 The `--include` and `--skip` options can be combined: `--include` first narrows the set of files to consider, then `--skip` further excludes files within that set.
+
+### Machine-Readable Output
+
+Use `--format` to get structured output for CI/CD automation. When specified, all human-readable output is suppressed.
+
+#### JSON (`--format json`)
+
+Outputs a JSON array of per-file results to stdout:
+
+```bash
+jenkinsfilelint Jenkinsfile --format json
+```
+
+```json
+[
+  {
+    "file": "Jenkinsfile",
+    "valid": false,
+    "message": "WorkflowScript: 12: Expected a stage @ line 12, column 5."
+  }
+]
+```
+
+Exit code is `0` when all files are valid, `1` otherwise.
+
+#### GitHub Annotations (`--format github`)
+
+Emits [GitHub Actions workflow annotations](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message) for invalid files. Line numbers are parsed from Jenkins error messages:
+
+```bash
+jenkinsfilelint Jenkinsfile --format github
+```
+
+```text
+::error file=Jenkinsfile,line=12::WorkflowScript: 12: Expected a stage @ line 12, column 5.
+```
+
+Valid files produce no output. This format is ideal for:
+- **GitHub Actions** — inline annotations in PR diffs
+- **Jenkins pipeline self-validation** — parseable by pipeline scripts
+- **External validators** (ODS, custom CI systems) — structured, machine-friendly output
 
 ### Pre-commit Hook
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Valid files produce no output. This format is ideal for:
 - **Jenkins pipeline self-validation** — parseable by pipeline scripts
 - **External validators** (ODS[^1], custom CI systems) — structured, machine-friendly output
 
-[^1]: [Open Delivery Stack](https://github.com/open-delivery-spec) — an open-source CI/CD framework for automated software delivery.
+[^1]: [Open Delivery Spec](https://github.com/open-delivery-spec) — an open-source delivery specifications and overnance in the AI era.
 
 ### Pre-commit Hook
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ jenkinsfilelint Jenkinsfile --format github
 Valid files produce no output. This format is ideal for:
 - **GitHub Actions** — inline annotations in PR diffs
 - **Jenkins pipeline self-validation** — parseable by pipeline scripts
-- **External validators** (ODS, custom CI systems) — structured, machine-friendly output
+- **External validators** (ODS[^1], custom CI systems) — structured, machine-friendly output
+
+[^1]: [Open Delivery Stack](https://github.com/opendeliverystack) — an open-source CI/CD framework for automated software delivery.
 
 ### Pre-commit Hook
 

--- a/jenkinsfilelint/cli.py
+++ b/jenkinsfilelint/cli.py
@@ -4,10 +4,61 @@
 import sys
 import argparse
 import io
+import json
+import re
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from .linter import JenkinsfileLinter
 from . import __version__
+
+
+def _extract_line_number(message: str) -> Optional[int]:
+    """Extract line number from a Jenkins validation error message.
+
+    Jenkins error messages often follow patterns like:
+        WorkflowScript: 12: Expected a stage...
+        WorkflowScript: 5: unexpected token: ...
+
+    Args:
+        message: The error message from Jenkins validation.
+
+    Returns:
+        The line number if found, None otherwise.
+    """
+    match = re.search(r'WorkflowScript[:\s]+(\d+)', message)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _format_json(results: List[Dict[str, Any]]) -> None:
+    """Output validation results as JSON to stdout.
+
+    Args:
+        results: List of per-file result dicts with keys: file, valid, message.
+    """
+    json.dump(results, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def _format_github(results: List[Dict[str, Any]]) -> None:
+    """Output validation results as GitHub Actions workflow annotations.
+
+    Emits GitHub workflow command annotations for each invalid file.
+    Format: ::error file=<path>,line=<N>::<message>
+
+    Args:
+        results: List of per-file result dicts with keys: file, valid, message.
+    """
+    for result in results:
+        if result["valid"]:
+            continue
+        line = _extract_line_number(result["message"])
+        if line is not None:
+            annotation = f'::error file={result["file"]},line={line}::{result["message"]}'
+        else:
+            annotation = f'::error file={result["file"]}::{result["message"]}'
+        print(annotation)
 
 
 def should_skip_file(filepath: str, skip_patterns: Optional[List[str]]) -> bool:
@@ -122,6 +173,15 @@ def main():
         "matching at least one pattern are validated. Can be used multiple times. "
         "Example: --include 'Jenkinsfile*' --include 'pipelines/*.groovy'",
     )
+    parser.add_argument(
+        "--format",
+        choices=["json", "github"],
+        default=None,
+        help="Output format for machine consumption. "
+        "'json' writes per-file structured JSON. "
+        "'github' emits GitHub Actions workflow annotations. "
+        "Default: human-readable text output.",
+    )
 
     args = parser.parse_args()
 
@@ -135,26 +195,34 @@ def main():
     # Validate all provided files
     all_valid = True
     printed_messages = set()  # Track messages already printed for deduplication
+    machine_results: List[Dict[str, Any]] = []
+    use_machine_format = args.format is not None
 
     for jenkinsfile in args.jenkinsfile:
         # Check if file should be included (whitelist)
         if not should_include_file(jenkinsfile, args.include):
-            if args.verbose:
+            if args.verbose and not use_machine_format:
                 print(f"⊘ {jenkinsfile}: Skipped (does not match include pattern)")
             continue
 
         # Check if file should be skipped (blacklist)
         if should_skip_file(jenkinsfile, args.skip):
-            if args.verbose:
+            if args.verbose and not use_machine_format:
                 print(f"⊘ {jenkinsfile}: Skipped (matches skip pattern)")
             continue
 
-        if args.verbose:
+        if args.verbose and not use_machine_format:
             print(f"Validating {jenkinsfile}...")
 
         is_valid, message = linter.validate(jenkinsfile)
 
-        if is_valid:
+        if use_machine_format:
+            machine_results.append({
+                "file": jenkinsfile,
+                "valid": is_valid,
+                "message": message,
+            })
+        elif is_valid:
             # Show valid status for multiple files or when verbose
             if args.verbose or len(args.jenkinsfile) > 1:
                 print(f"✓ {jenkinsfile}: Valid")
@@ -167,8 +235,18 @@ def main():
                 printed_messages.add(message)
             all_valid = False
 
+    # Output machine-readable results if format was requested
+    if use_machine_format:
+        if args.format == "json":
+            _format_json(machine_results)
+        elif args.format == "github":
+            _format_github(machine_results)
+
     # Exit with appropriate code
-    sys.exit(0 if all_valid else 1)
+    if use_machine_format:
+        sys.exit(0 if all(r["valid"] for r in machine_results) else 1)
+    else:
+        sys.exit(0 if all_valid else 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,14 @@ import os
 import pytest
 import tempfile
 from unittest.mock import patch, Mock
-from jenkinsfilelint.cli import main, should_skip_file, should_include_file
+from jenkinsfilelint.cli import (
+    main,
+    should_skip_file,
+    should_include_file,
+    _extract_line_number,
+    _format_json,
+    _format_github,
+)
 
 
 class TestCLIMain:
@@ -690,3 +697,386 @@ class TestWindowsUTF8Encoding:
                     with patch("sys.argv", ["jenkinsfilelint", "--help"]):
                         with pytest.raises(SystemExit):
                             main()
+
+
+class TestExtractLineNumber:
+    """Tests for _extract_line_number helper."""
+
+    def test_extracts_from_workflowscript_colon_space(self):
+        msg = "WorkflowScript: 12: Expected a stage @ line 12, column 1."
+        assert _extract_line_number(msg) == 12
+
+    def test_extracts_from_workflowscript_colon(self):
+        msg = "WorkflowScript: 5: unexpected token: }"
+        assert _extract_line_number(msg) == 5
+
+    def test_returns_none_for_no_match(self):
+        msg = "Error connecting to Jenkins: Connection refused"
+        assert _extract_line_number(msg) is None
+
+    def test_returns_none_for_empty_message(self):
+        assert _extract_line_number("") is None
+
+    def test_extracts_first_line_number(self):
+        msg = "WorkflowScript: 12: error; WorkflowScript: 20: another error"
+        assert _extract_line_number(msg) == 12
+
+
+class TestFormatJSON:
+    """Tests for _format_json output function."""
+
+    def test_outputs_json_array(self, capsys):
+        results = [
+            {"file": "Jenkinsfile", "valid": True, "message": "success"},
+        ]
+        _format_json(results)
+        captured = capsys.readouterr()
+        import json
+        parsed = json.loads(captured.out)
+        assert isinstance(parsed, list)
+        assert parsed[0]["file"] == "Jenkinsfile"
+        assert parsed[0]["valid"] is True
+
+    def test_outputs_multiple_files(self, capsys):
+        results = [
+            {"file": "a.groovy", "valid": True, "message": "ok"},
+            {"file": "b.groovy", "valid": False, "message": "error"},
+        ]
+        _format_json(results)
+        captured = capsys.readouterr()
+        import json
+        parsed = json.loads(captured.out)
+        assert len(parsed) == 2
+
+    def test_outputs_empty_list(self, capsys):
+        _format_json([])
+        captured = capsys.readouterr()
+        import json
+        parsed = json.loads(captured.out)
+        assert parsed == []
+
+
+class TestFormatGitHub:
+    """Tests for _format_github output function."""
+
+    def test_no_output_for_valid_files(self, capsys):
+        results = [
+            {"file": "Jenkinsfile", "valid": True, "message": "ok"},
+        ]
+        _format_github(results)
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_emits_annotation_with_line_number(self, capsys):
+        results = [
+            {"file": "Jenkinsfile", "valid": False, "message": "WorkflowScript: 12: Expected a stage"},
+        ]
+        _format_github(results)
+        captured = capsys.readouterr()
+        assert "::error file=Jenkinsfile,line=12::WorkflowScript: 12: Expected a stage" in captured.out
+
+    def test_emits_annotation_without_line_number(self, capsys):
+        results = [
+            {"file": "Jenkinsfile", "valid": False, "message": "Connection refused"},
+        ]
+        _format_github(results)
+        captured = capsys.readouterr()
+        assert "::error file=Jenkinsfile::Connection refused" in captured.out
+
+    def test_multiple_errors(self, capsys):
+        results = [
+            {"file": "a.groovy", "valid": False, "message": "WorkflowScript: 5: error a"},
+            {"file": "b.groovy", "valid": True, "message": "ok"},
+            {"file": "c.groovy", "valid": False, "message": "WorkflowScript: 3: error c"},
+        ]
+        _format_github(results)
+        captured = capsys.readouterr()
+        lines = captured.out.strip().split("\n")
+        assert len(lines) == 2  # only invalid files
+        assert "file=a.groovy,line=5" in lines[0]
+        assert "file=c.groovy,line=3" in lines[1]
+
+
+class TestCLIFormatOption:
+    """Tests for the --format CLI option."""
+
+    def test_format_json_single_valid(self, capsys):
+        """Test --format json with a single valid file."""
+        import json
+
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "jenkinsfilelint",
+                    "--format", "json",
+                    "--jenkins-url", "https://jenkins.example.com",
+                    temp_path,
+                ],
+            ):
+                with patch("jenkinsfilelint.linter.requests.post") as mock_post:
+                    mock_response = Mock()
+                    mock_response.status_code = 200
+                    mock_response.json.return_value = {"status": "ok"}
+                    mock_response.raise_for_status = Mock()
+                    mock_post.return_value = mock_response
+
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            parsed = json.loads(captured.out)
+            assert isinstance(parsed, list)
+            assert len(parsed) == 1
+            assert parsed[0]["file"] == temp_path
+            assert parsed[0]["valid"] is True
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_json_single_invalid(self, capsys):
+        """Test --format json with an invalid file (no credentials)."""
+        import json
+
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch("sys.argv", ["jenkinsfilelint", "--format", "json", temp_path]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 1
+
+            captured = capsys.readouterr()
+            parsed = json.loads(captured.out)
+            assert len(parsed) == 1
+            assert parsed[0]["file"] == temp_path
+            assert parsed[0]["valid"] is False
+            assert "credentials required" in parsed[0]["message"].lower()
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_json_multiple_files(self, capsys):
+        """Test --format json with multiple files."""
+        import json
+
+        f1 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix="1.groovy")
+        f1.write("pipeline { agent any }")
+        f1.flush()
+        f1.close()
+        temp_path1 = f1.name
+
+        f2 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix="2.groovy")
+        f2.write("pipeline { agent any }")
+        f2.flush()
+        f2.close()
+        temp_path2 = f2.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "jenkinsfilelint",
+                    "--format", "json",
+                    "--jenkins-url", "https://jenkins.example.com",
+                    temp_path1,
+                    temp_path2,
+                ],
+            ):
+                with patch("jenkinsfilelint.linter.requests.post") as mock_post:
+                    mock_response = Mock()
+                    mock_response.status_code = 200
+                    mock_response.json.return_value = {"status": "ok"}
+                    mock_response.raise_for_status = Mock()
+                    mock_post.return_value = mock_response
+
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            parsed = json.loads(captured.out)
+            assert len(parsed) == 2
+            assert parsed[0]["valid"] is True
+            assert parsed[1]["valid"] is True
+        finally:
+            os.unlink(temp_path1)
+            os.unlink(temp_path2)
+
+    def test_format_json_no_human_output(self, capsys):
+        """Test that --format json suppresses human-readable output."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "jenkinsfilelint",
+                    "--format", "json",
+                    "--verbose",
+                    "--jenkins-url", "https://jenkins.example.com",
+                    temp_path,
+                ],
+            ):
+                with patch("jenkinsfilelint.linter.requests.post") as mock_post:
+                    mock_response = Mock()
+                    mock_response.status_code = 200
+                    mock_response.json.return_value = {"status": "ok"}
+                    mock_response.raise_for_status = Mock()
+                    mock_post.return_value = mock_response
+
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            # Should not contain human-readable text like "Validating" or "Valid"
+            assert "Validating" not in captured.out
+            assert "\u2298" not in captured.out  # ⊘
+            # Should be valid JSON
+            import json
+            json.loads(captured.out)
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_github_single_valid(self, capsys):
+        """Test --format github with a valid file produces no output."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "jenkinsfilelint",
+                    "--format", "github",
+                    "--jenkins-url", "https://jenkins.example.com",
+                    temp_path,
+                ],
+            ):
+                with patch("jenkinsfilelint.linter.requests.post") as mock_post:
+                    mock_response = Mock()
+                    mock_response.status_code = 200
+                    mock_response.json.return_value = {"status": "ok"}
+                    mock_response.raise_for_status = Mock()
+                    mock_post.return_value = mock_response
+
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            # GitHub format should produce no output for valid files
+            assert captured.out == ""
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_github_single_invalid(self, capsys):
+        """Test --format github with an invalid file."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch("sys.argv", ["jenkinsfilelint", "--format", "github", temp_path]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 1
+
+            captured = capsys.readouterr()
+            assert "::error file=" in captured.out
+            # No human-readable output
+            assert "Validating" not in captured.out
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_github_with_jenkins_error(self, capsys):
+        """Test --format github with a WorkflowScript error including line number."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("invalid pipeline")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "jenkinsfilelint",
+                    "--format", "github",
+                    "--jenkins-url", "https://jenkins.example.com",
+                    temp_path,
+                ],
+            ):
+                with patch("jenkinsfilelint.linter.requests.post") as mock_post:
+                    mock_response = Mock()
+                    mock_response.status_code = 200
+                    mock_response.text = "WorkflowScript: 12: Expected a stage"
+                    mock_response.json.side_effect = ValueError("Not JSON")
+                    mock_response.raise_for_status = Mock()
+                    mock_post.return_value = mock_response
+
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 1
+
+            captured = capsys.readouterr()
+            # Should include line number parsed from message
+            assert f"::error file={temp_path},line=12::" in captured.out
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_github_no_human_output(self, capsys):
+        """Test that --format github suppresses human output even with --verbose."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with patch(
+                "sys.argv",
+                [
+                    "jenkinsfilelint",
+                    "--format", "github",
+                    "--verbose",
+                    temp_path,
+                ],
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 1
+
+            captured = capsys.readouterr()
+            assert "Validating" not in captured.out
+            assert "\u2298" not in captured.out  # ⊘
+            assert "::error file=" in captured.out
+        finally:
+            os.unlink(temp_path)
+
+    def test_format_invalid_choice_rejected(self, capsys):
+        """Test that an invalid --format value is rejected by argparse."""
+        with patch("sys.argv", ["jenkinsfilelint", "--format", "xml", "Jenkinsfile"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            # argparse exits with code 2 for invalid choice
+            assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

Add two new machine-friendly output formats to the CLI: `--format json` and `--format github`.

### Usage

```bash
# JSON output - structured, parseable by any tool
jenkinsfilelint Jenkinsfile --format json
# -> [{"file": "Jenkinsfile", "valid": false, "message": "WorkflowScript: 12: Expected a stage..."}]

# GitHub Actions annotations with parsed line numbers
jenkinsfilelint Jenkinsfile --format github
# -> ::error file=Jenkinsfile,line=12::WorkflowScript: 12: Expected a stage...

# Default human-readable behavior is unchanged
jenkinsfilelint Jenkinsfile
```

### Changes

**`cli.py`**:
- New `_extract_line_number()` helper - parses line numbers from Jenkins error patterns like `WorkflowScript: 12: ...`
- New `_format_json(results)` - outputs per-file results as pretty-printed JSON array
- New `_format_github(results)` - emits GitHub Actions `::error` annotations (only for invalid files)
- New `--format` argument with choices `json` / `github`
- When `--format` is used, human-readable output (including `--verbose` messages) is fully suppressed

**Tests** (21 new, 71 total):
- `TestExtractLineNumber` - 5 tests for line number parsing
- `TestFormatJSON` - 3 tests for JSON formatter
- `TestFormatGitHub` - 4 tests for GitHub annotation formatter
- `TestCLIFormatOption` - 9 end-to-end CLI tests

### Value

This enables three key scenarios:
1. **GitHub Action annotations** - inline errors in PR diffs
2. **Jenkins pipeline self-validation** - parseable by pipeline scripts
3. **ODS / external validator integration** - structured output for Open Delivery Stack validators
