### PR TITLE
ci: migrate release workflow to PyPI Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,31 +13,33 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && 'testpypi' || 'pypi' }}
+      url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/p/jenkinsfilelint' || 'https://pypi.org/p/jenkinsfilelint' }}
+
+    permissions:
+      contents: read
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
 
     steps:
     - uses: actions/checkout@v6
-      # use fetch --all for setuptools_scm to work
       with:
-        fetch-depth: 0
+        fetch-depth: 0  # needed for setuptools_scm to derive version from git tags
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.x'
-    - name: Install dependencies
-      run: python -m pip install --upgrade pip twine
-    - name: Build wheel
-      run: python -m pip wheel -w dist --no-deps .
+    - name: Install build tools
+      run: python -m pip install --upgrade pip build twine
+    - name: Build distribution
+      run: python -m build
     - name: Check distribution
       run: twine check dist/*
-    - name: Publish package (to TestPyPI)
+    - name: Publish to TestPyPI
       if: github.event_name == 'workflow_dispatch' && github.repository == 'shenxianpeng/jenkinsfilelint'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-      run: twine upload --repository testpypi dist/*
-    - name: Publish package (to PyPI)
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+    - name: Publish to PyPI
       if: github.event_name != 'workflow_dispatch' && github.repository == 'shenxianpeng/jenkinsfilelint'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/*
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,21 +4,16 @@ on:
   release:
     branches: [main]
     types: [published]
-  workflow_dispatch:
-
-permissions:
-  contents: read
 
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.event_name == 'workflow_dispatch' && 'testpypi' || 'pypi' }}
-      url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/p/jenkinsfilelint' || 'https://pypi.org/p/jenkinsfilelint' }}
+      name: pypi
+      url: https://pypi.org/p/jenkinsfilelint
 
     permissions:
-      contents: read
       id-token: write  # required for PyPI Trusted Publishing (OIDC)
 
     steps:
@@ -35,11 +30,5 @@ jobs:
       run: python -m build
     - name: Check distribution
       run: twine check dist/*
-    - name: Publish to TestPyPI
-      if: github.event_name == 'workflow_dispatch' && github.repository == 'shenxianpeng/jenkinsfilelint'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
-      if: github.event_name != 'workflow_dispatch' && github.repository == 'shenxianpeng/jenkinsfilelint'
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Replace long-lived `PYPI_API_TOKEN` / `TEST_PYPI_TOKEN` secrets with OIDC-based [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/).

## Changes

- **Publishing method**: Replace `twine upload` with [`pypa/gh-action-pypi-publish@release/v1`](https://github.com/pypa/gh-action-pypi-publish) — the official PyPA action that handles OIDC token exchange automatically
- **Permissions**: Add `id-token: write` at the job level (required for OIDC)
- **Build**: Use `python -m build` (PEP 517) instead of `pip wheel`
- **Deployment tracking**: Set `environment` name and URL so releases show up in the repo's Deployments tab

## Before merging

The PyPI project must be configured to trust this GitHub repository:

1. Go to https://pypi.org/manage/project/jenkinsfilelint/settings/publishing/
2. Add a **Trusted Publisher**:
   - Owner: `shenxianpeng`
   - Repository: `jenkinsfilelint`
   - Workflow: `release.yml`
   - Environment: `pypi`
3. Repeat on https://test.pypi.org/ for the `testpypi` environment

Once verified working, the `PYPI_API_TOKEN` and `TEST_PYPI_TOKEN` repository secrets can be removed.