### PR TITLE
chore: add CONTRIBUTING.md, pin action hashes, add license field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       id-token: write  # required for PyPI Trusted Publishing (OIDC)
 
     steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0  # needed for setuptools_scm to derive version from git tags
     - name: Set up Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.x'
     - name: Install build tools
@@ -31,4 +31,4 @@ jobs:
     - name: Check distribution
       run: twine check dist/*
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       id-token: write  # required for PyPI Trusted Publishing (OIDC)
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
       with:
         fetch-depth: 0  # needed for setuptools_scm to derive version from git tags
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
       with:
         python-version: '3.x'
     - name: Install build tools
@@ -31,4 +31,4 @@ jobs:
     - name: Check distribution
       run: twine check dist/*
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Contributions are welcome! Here's how to get started.
+
+## Setup
+
+```bash
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Run pre-commit before submitting:
+
+```bash
+pre-commit run --all-files
+```
+
+## Testing
+
+```bash
+pytest tests/ -v --cov=jenkinsfilelint
+```
+
+## Conventions
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
+- Keep PRs focused — one logical change per PR.
+- Update the README if your change affects usage or configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
     {name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com"},
 ]
 description = "A Jenkinsfile linter that validates Jenkinsfiles using Jenkins API"
+license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [


### PR DESCRIPTION
Three small fixes:

1. **Add CONTRIBUTING.md** — simple contributing guide with setup and pre-commit instructions
2. **Pin action hashes in release.yml** — replace `@v6` / `@release/v1` tags with commit hashes, consistent with main.yml
3. **Add license field in pyproject.toml** — `license = {text = "MIT"}` per PEP 621