### PR TITLE
fix: change jenkinsfilelint hook stage from manual to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
         exclude: ^jenkinsfilelint/
         pass_filenames: true
         verbose: true
-        stages: [manual]  # pre-commit run jenkinsfilelint --all-files --hook-stage manual
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

The `jenkinsfilelint` pre-commit hook was configured with `stages: [manual]`, which caused it to be **skipped** during `git commit`. It only ran when explicitly invoked with `pre-commit run --hook-stage manual`.

## Root Cause

`stages: [manual]` tells pre-commit to only run this hook during the `manual` stage, not the default `commit` stage. So every `git commit` was showing:

```
jenkinsfilelint......................................(no files to check)Skipped
```

## Fix

Changed `stages: [manual]` → `stages: [pre-commit]` so the hook runs automatically on every commit.

```diff
-        stages: [manual]  # pre-commit run jenkinsfilelint --all-files --hook-stage manual
+        stages: [pre-commit]
```

## Verification

After the fix, `jenkinsfilelint` will run automatically when committing changes to `Jenkinsfile` or any `.groovy` file.