### PR TITLE
fix: make files regex case-insensitive in pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,5 @@
   entry: jenkinsfilelint
   language: python
   types: [file]
-  files: ^.*(Jenkinsfile.*|.*\.groovy)$
+  files: (?i)^(.*/)?(Jenkinsfile[^/]*|.*\.groovy)$
   require_serial: true


### PR DESCRIPTION
## Summary

The `files` regex in .pre-commit-hooks.yaml lacked the `(?i)` case-insensitive flag, causing the `jenkinsfilelint` hook to **skip files** on case-insensitive filesystems (e.g., macOS APFS/HFS+).

## Root Cause

On macOS, the filesystem is case-insensitive by default. When a file is named `jenkinsfile` (lowercase) on disk, typing `vi Jenkinsfile` (capital J) works because macOS resolves it to the same file. However, `git` returns the **actual filename** from disk (`jenkinsfile`, lowercase), and the old regex without `(?i)` was case-sensitive — causing a mismatch:

```
jenkinsfilelint......................................(no files to check)Skipped
```

## Fix

```diff
-  files: ^.*(Jenkinsfile.*|.*\.groovy)$
+  files: (?i)^(.*/)?(Jenkinsfile[^/]*|.*\.groovy)$
```

Three improvements:
1. **`(?i)`** — case-insensitive matching (the core fix)
2. **`(.*/)?`** — cleaner path prefix matching (avoids greedy backtracking)
3. **`Jenkinsfile[^/]*`** — won't match hidden files like `.Jenkinsfile`

## Before / After

| Filename | Before | After |
|----------|--------|-------|
| `Jenkinsfile` | ✅ | ✅ |
| `jenkinsfile` (lowercase) | ❌ SKIP | ✅ MATCH |
| `JENKINSFILE` | ❌ SKIP | ✅ MATCH |
| `test.Groovy` | ❌ SKIP | ✅ MATCH |
| `.Jenkinsfile` | ✅ (bug) | ❌ SKIP (correct) |