### PR TITLE
chore: update links from shenxianpeng to jenkinsci org

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,4 +19,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
-          config-name: github:shenxianpeng/.github:/.github/release-drafter.yml
+          config-name: github:jenkinsci/.github:/.github/release-drafter.yml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jenkinsfile Lint
 
-[![CI](https://github.com/shenxianpeng/jenkinsfilelint/actions/workflows/main.yml/badge.svg)](https://github.com/shenxianpeng/jenkinsfilelint/actions/workflows/main.yml)
-[![codecov](https://codecov.io/gh/shenxianpeng/jenkinsfilelint/graph/badge.svg?token=Z9UTXBL2XG)](https://codecov.io/gh/shenxianpeng/jenkinsfilelint)
+[![CI](https://github.com/jenkinsci/jenkinsfilelint/actions/workflows/main.yml/badge.svg)](https://github.com/jenkinsci/jenkinsfilelint/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/jenkinsci/jenkinsfilelint/graph/badge.svg?token=Z9UTXBL2XG)](https://codecov.io/gh/jenkinsci/jenkinsfilelint)
 [![PyPI version](https://img.shields.io/pypi/v/jenkinsfilelint)](https://pypi.org/project/jenkinsfilelint/)
 
 Catch Jenkinsfile syntax errors before they break your CI.
@@ -29,7 +29,7 @@ Catch Jenkinsfile syntax errors before they break your CI.
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: https://github.com/shenxianpeng/jenkinsfilelint
+  - repo: https://github.com/jenkinsci/jenkinsfilelint
     rev: # use the latest or a specific version, e.g. v1.4.0
     hooks:
       - id: jenkinsfilelint

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Jenkinsfile Lint
 
 [![CI](https://github.com/jenkinsci/jenkinsfilelint/actions/workflows/main.yml/badge.svg)](https://github.com/jenkinsci/jenkinsfilelint/actions/workflows/main.yml)
-[![codecov](https://codecov.io/gh/jenkinsci/jenkinsfilelint/graph/badge.svg?token=Z9UTXBL2XG)](https://codecov.io/gh/jenkinsci/jenkinsfilelint)
+[![codecov](https://codecov.io/gh/jenkinsci/jenkinsfilelint/graph/badge.svg?token=nGrwXORFtI)](https://codecov.io/gh/jenkinsci/jenkinsfilelint)
 [![PyPI version](https://img.shields.io/pypi/v/jenkinsfilelint)](https://pypi.org/project/jenkinsfilelint/)
 
 Catch Jenkinsfile syntax errors before they break your CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/shenxianpeng/jenkinsfilelint"
+Homepage = "https://github.com/jenkinsci/jenkinsfilelint"
 
 [project.scripts]
 jenkinsfilelint = "jenkinsfilelint.cli:main"


### PR DESCRIPTION
## Summary

Update all links in the project from the my personal repo `shenxianpeng/jenkinsfilelint` to the new Jenkins CI organization `jenkinsci/jenkinsfilelint`.

## Changes

- **README.md**: Updated CI badge URL, Codecov badge URL, and pre-commit hook repo URL
- **pyproject.toml**: Updated `[project.urls] Homepage`