### PR TITLE
chore: add official Jenkins blog post link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Catch Jenkinsfile syntax errors before they break your CI.
 
 `jenkinsfilelint` sends your Jenkinsfiles to your Jenkins server's `/pipeline-model-converter/validate` endpoint for real syntax validation. It's primarily a [pre-commit](https://pre-commit.com/) hook, but also works as a CLI tool.
 
+> 📖 Read the [official blog post](https://www.jenkins.io/blog/2026/06/08/jenkinsfilelint-pre-commit/) for the story behind this tool.
+
 ![demo](demo.gif)
 
 ## Table of Contents


### PR DESCRIPTION
Adds a **Resources** section to the README linking to the official Jenkins blog post: [Introducing Jenkinsfile Lint: Catch Pipeline Syntax Errors Before They Break Your CI](https://www.jenkins.io/blog/2026/06/08/jenkinsfilelint-pre-commit/).

The blog post provides narrative context (motivation, design rationale, real-world usage) that complements the README's technical reference style.

Changes:
- New `## Resources` section in README with blog link
- Updated Table of Contents accordingly