### PR TITLE
feat: use full semver (x.y.z) for Release Drafter versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+# Extends the shared Jenkins Release Drafter configuration
+# but overrides versioning to use full semver (x.y.z) instead of (x.y).
+_extends: github:jenkinsci/.github:/.github/release-drafter.yml
+name-template: $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,5 +18,5 @@ jobs:
 
     steps:
       - uses: release-drafter/release-drafter@v7
-        with:
-          config-name: github:jenkinsci/.github:/.github/release-drafter.yml
+        # Uses local .github/release-drafter.yml which extends the shared
+        # jenkinsci/.github config but overrides versioning to full semver (x.y.z).


### PR DESCRIPTION
## Summary

Override the shared `jenkinsci/.github` Release Drafter config to use full semver versioning (`x.y.z`) instead of 2-part versioning (`x.y`).

## Problem

The current workflow uses `config-name: github:jenkinsci/.github:/.github/release-drafter.yml`, which sets `version-template: \$MAJOR.\$MINOR`. This produces tags like `1.2` instead of `1.2.3`.

## Solution

1. **New local config** (`.github/release-drafter.yml`): Uses `_extends` to inherit from the shared Jenkins config, but overrides three keys:
   - `version-template: \$MAJOR.\$MINOR.\$PATCH` — display full semver
   - `tag-template: \$NEXT_PATCH_VERSION` — auto-bump based on PR labels (breaking → major bump, feature → minor bump, fix → patch bump)
   - `name-template: \$NEXT_PATCH_VERSION` — match the tag

2. **Updated workflow** (`.github/workflows/release-drafter.yml`): Removed `config-name` so the action picks up the local config by default. All other settings (categories, autolabeler, replacers, etc.) are still inherited from the shared config.

## Versioning behavior

| PR Label | Version bump | Example |
|----------|-------------|---------|
| `breaking` | Major | `1.2.3` → `2.0.0` |
| `feature` / `enhancement` | Minor | `1.2.3` → `1.3.0` |
| `bug` / `fix` | Patch | `1.2.3` → `1.2.4` |

This is compatible with `setuptools_scm` which derives the Python package version from git tags.