### PR TITLE
fix: add Full Changelog footer link to release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,3 +4,8 @@ _extends: github:jenkinsci/.github:/.github/release-drafter.yml
 name-template: $NEXT_PATCH_VERSION
 tag-template: $NEXT_PATCH_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION


### PR DESCRIPTION
fixup of #33 

The shared `jenkinsci/.github` release-drafter template only outputs `$CHANGES` and lacks a **Full Changelog** comparison footer at the bottom of release notes.

This PR overrides the `template` in the local `.github/release-drafter.yml` to include a Full Changelog link that compares the previous tag with the next patch version, e.g.:

> **Full Changelog**: https://github.com/jenkinsci/jenkinsfilelint/compare/v1.3.0...v1.4.0