### PR TITLE
feat: add local Docker-based Jenkins server for Jenkinsfile validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,11 @@ updates:
       pip:
         patterns:
           - "*"
+  - package-ecosystem: docker
+    directory: /docker/
+    schedule:
+      interval: "monthly"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Build & Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/**"
+      - ".github/workflows/docker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docker/**"
+      - ".github/workflows/docker.yml"
+  schedule:
+    # Monthly rebuild to pick up Jenkins LTS and plugin updates
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: jenkinsfilelint-server
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3.0.0
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96  # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+            type=schedule,pattern={{date 'YYYY-MM'}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109823  # v6.0.0
+        with:
+          context: docker/
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,11 +31,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3.0.0
+        uses: docker/setup-buildx-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.0.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96  # v5.0.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
             type=schedule,pattern={{date 'YYYY-MM'}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109823  # v6.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: docker/
           push: ${{ github.event_name != 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Catch Jenkinsfile syntax errors before they break your CI.
 - [Usage](#usage)
   - [Pre-commit Hook](#pre-commit-hook)
   - [CLI](#cli)
+  - [Local mode (no remote Jenkins required)](#local-mode-no-remote-jenkins-required)
   - [Filtering files](#filtering-files)
 - [Configuration](#configuration)
 - [Security](#security)
@@ -27,6 +28,8 @@ Catch Jenkinsfile syntax errors before they break your CI.
 - [License](#license)
 
 ## Quick Start
+
+### With a remote Jenkins server
 
 ```yaml
 # .pre-commit-config.yaml
@@ -46,11 +49,35 @@ pip install pre-commit
 pre-commit install
 ```
 
+### With local Docker (no remote Jenkins required)
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/jenkinsci/jenkinsfilelint
+    rev: # use the latest or a specific version, e.g. v1.4.0
+    hooks:
+      - id: jenkinsfilelint
+        args: ["--local"]
+```
+
+```bash
+# Docker (or Podman) is the only requirement — no env vars needed
+pip install pre-commit
+pre-commit install
+```
+
+The first commit will pull the container image and start Jenkins (~20–40s cold
+start). Subsequent commits reuse the running container and complete in
+milliseconds.
+
 ## Usage
 
 ### Pre-commit Hook
 
-Once installed, every commit that touches a Jenkinsfile is validated:
+Once installed, every commit that touches a Jenkinsfile is validated.
+
+**Remote mode** (default — requires ``JENKINS_URL``):
 
 ```bash
 git commit -m "Update Jenkinsfile"
@@ -81,6 +108,43 @@ pip install jenkinsfilelint
 jenkinsfilelint Jenkinsfile
 jenkinsfilelint Jenkinsfile Jenkinsfile.prod tests/Jenkinsfile
 ```
+
+### Local mode (no remote Jenkins required)
+
+If you have Docker (or Podman) installed, you can validate without any remote
+Jenkins server. The tool automatically manages a minimal Jenkins container on
+your machine:
+
+```bash
+# First run: starts a Jenkins container (~20–40s cold start)
+jenkinsfilelint --local Jenkinsfile
+
+# Subsequent runs: reuses the running container (milliseconds)
+jenkinsfilelint --local Jenkinsfile
+
+# Stop the container when you're done
+jenkinsfilelint server stop
+```
+
+The container runs in unsecured mode, listening only on ``127.0.0.1`` so it is
+safe for local use. The image is hosted on GitHub Container Registry and is
+automatically pulled on first use.
+
+**Server lifecycle commands:**
+
+```bash
+jenkinsfilelint server status   # Check if the container is running
+jenkinsfilelint server restart  # Restart the container
+```
+
+> [!IMPORTANT]
+> Local mode validates **vanilla Declarative Pipeline syntax only**. If your
+> production Jenkins has plugins that provide custom options, agents, or steps
+> (e.g., custom shared libraries), local mode may not catch errors related to
+> those plugins. For authoritative validation, use the regular remote mode
+> pointing at your real Jenkins server.
+>
+> In short: `--local` = fast syntax gate, remote = authoritative validation.
 
 ### Filtering files
 
@@ -121,18 +185,27 @@ You can also combine both — `--include` narrows first, then `--skip` removes f
 
 Supply credentials via environment variables (recommended) or CLI flags:
 
-| Env Variable    | CLI Flag       | Required |
-|-----------------|----------------|----------|
-| `JENKINS_URL`   | `--jenkins-url`| Yes      |
-| `JENKINS_USER`  | `--username`   | No *     |
-| `JENKINS_TOKEN` | `--token`      | No *     |
+| Env Variable               | CLI Flag        | Required |
+|----------------------------|-----------------|----------|
+| `JENKINS_URL`              | `--jenkins-url` | Yes *    |
+| `JENKINS_USER`             | `--username`    | No **    |
+| `JENKINS_TOKEN`            | `--token`       | No **    |
+| `JENKINSFILELINT_SERVER_IMAGE` | —          | No       |
 
-\* Only required if your Jenkins requires authentication.
+\* Not required in ``--local`` mode.
+\*\* Only required if your Jenkins requires authentication (not used in ``--local`` mode).
 
 > [!TIP]
 > Even if your Jenkins allows anonymous access for validation, using an API token is recommended for production setups.
 
 CLI flags override env vars. There is no config file.
+
+### Local Docker image
+
+By default, ``--local`` mode uses the official image
+``ghcr.io/jenkinsci/jenkinsfilelint-server:latest``. You can override this with
+the ``JENKINSFILELINT_SERVER_IMAGE`` environment variable if you maintain a
+custom build.
 
 ## Security
 
@@ -147,6 +220,8 @@ CLI flags override env vars. There is no config file.
 
 `jenkinsfilelint` is a **syntax gate** — it checks that your Declarative Pipeline syntax is valid.
 
+### Remote mode (default)
+
 1. Reads the local Jenkinsfile.
 2. POSTs it to `<JENKINS_URL>/pipeline-model-converter/validate`.
 3. Jenkins parses the Pipeline and returns `"ok"` or errors.
@@ -154,10 +229,24 @@ CLI flags override env vars. There is no config file.
 
 It only answers: **"Will Jenkins accept this syntax?"**
 
+### Local mode (`--local`)
+
+Same validation, zero infrastructure:
+
+1. Checks if a local Jenkins container is already running (identified by label).
+2. If not, starts one with ``docker run -d`` (or ``podman``).
+3. Waits for Jenkins to become ready by polling ``/login``.
+4. Uses the **exact same** validate endpoint at ``http://127.0.0.1:<port>``.
+5. Container stays running — subsequent invocations are near-instant.
+
+This gives you 100% validation fidelity without maintaining a remote Jenkins
+server. The only requirement is Docker or Podman on your machine.
+
 ## Requirements
 
 - Python 3.10+
-- Jenkins server with the Pipeline plugin
+- For remote mode: a Jenkins server with the Pipeline plugin installed
+- For ``--local`` mode: [Docker](https://docker.com) or [Podman](https://podman.io)
 
 ## Contributing
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,46 @@
+# jenkinsfilelint-server
+#
+# Minimal Jenkins image for local Declarative Pipeline validation.
+# Only includes the plugins needed for the /pipeline-model-converter/validate endpoint.
+# Runs in unsecured mode bound to 127.0.0.1 — safe for local-only use.
+#
+# Build:
+#   docker build -t jenkinsfilelint-server docker/
+#
+# Run:
+#   docker run -d --rm \
+#     --name jenkinsfilelint-server \
+#     -p 127.0.0.1:18080:8080 \
+#     jenkinsfilelint-server
+
+FROM jenkins/jenkins:lts-jdk21
+
+LABEL org.opencontainers.image.source="https://github.com/jenkinsci/jenkinsfilelint"
+LABEL org.opencontainers.image.description="Minimal Jenkins image for Declarative Pipeline syntax validation"
+LABEL org.opencontainers.image.licenses="MIT"
+
+USER root
+
+# Install plugins — pipeline-model-definition provides the validate endpoint,
+# configuration-as-code lets us bootstrap in unsecured mode without the setup wizard.
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt
+
+# JCasC configuration: unsecured, no executors, loopback-only
+COPY jenkins.yaml /usr/share/jenkins/ref/jenkins.yaml
+ENV CASC_JENKINS_CONFIG=/usr/share/jenkins/ref/jenkins.yaml
+
+USER jenkins
+
+# Disable the setup wizard and update-center checks
+ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
+
+# Listen on all interfaces inside the container.
+# Security is enforced by the Docker port mapping (-p 127.0.0.1:18080:8080)
+# which binds to loopback on the host side.
+ENV JENKINS_OPTS="--httpListenAddress=0.0.0.0"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -sf http://127.0.0.1:8080/login || exit 1

--- a/docker/jenkins.yaml
+++ b/docker/jenkins.yaml
@@ -1,0 +1,13 @@
+# Jenkins Configuration-as-Code for jenkinsfilelint-server
+# Unsecured mode — safe for local-only use (Docker binds to 127.0.0.1 on the host).
+jenkins:
+  authorizationStrategy:
+    unsecured: {}
+  securityRealm:
+    none: {}
+  disableRememberMe: true
+  numExecutors: 0
+  mode: NORMAL
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: true

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -1,0 +1,5 @@
+# Core plugin for Declarative Pipeline validation (/pipeline-model-converter/validate)
+pipeline-model-definition
+
+# JCasC for zero-config unsecured setup
+configuration-as-code

--- a/jenkinsfilelint/__init__.py
+++ b/jenkinsfilelint/__init__.py
@@ -2,6 +2,8 @@
 
 from importlib.metadata import version, PackageNotFoundError
 
+from . import local as local  # re-export for mock.patch
+
 try:
     __version__ = version("jenkinsfilelint")
 except PackageNotFoundError:

--- a/jenkinsfilelint/cli.py
+++ b/jenkinsfilelint/cli.py
@@ -5,8 +5,9 @@ import sys
 import argparse
 import io
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Set
 from .linter import JenkinsfileLinter
+from .local import LocalJenkins, handle_server_command
 from . import __version__
 
 
@@ -53,8 +54,84 @@ def should_include_file(filepath: str, include_patterns: Optional[List[str]]) ->
     return False
 
 
+def _validate_files(linter: JenkinsfileLinter, args: argparse.Namespace) -> None:
+    """Shared validation loop used by both remote and local modes."""
+    all_valid = True
+    printed_messages: Set[str] = set()
+
+    for jenkinsfile in args.jenkinsfile:
+        # Check if file should be included (whitelist)
+        if not should_include_file(jenkinsfile, args.include):
+            if args.verbose:
+                print(f"⊘ {jenkinsfile}: Skipped (does not match include pattern)")
+            continue
+
+        # Check if file should be skipped (blacklist)
+        if should_skip_file(jenkinsfile, args.skip):
+            if args.verbose:
+                print(f"⊘ {jenkinsfile}: Skipped (matches skip pattern)")
+            continue
+
+        if args.verbose:
+            print(f"Validating {jenkinsfile}...")
+
+        is_valid, message = linter.validate(jenkinsfile)
+
+        if is_valid:
+            # Show valid status for multiple files or when verbose
+            if args.verbose or len(args.jenkinsfile) > 1:
+                print(f"✓ {jenkinsfile}: Valid")
+            if args.verbose and message:
+                print(f"  {message}")
+        else:
+            # Deduplicate error messages (e.g., credentials errors)
+            if message not in printed_messages:
+                print(f"  {message}", file=sys.stderr)
+                printed_messages.add(message)
+            all_valid = False
+
+    sys.exit(0 if all_valid else 1)
+
+
+def _run_remote_validation(args: argparse.Namespace) -> None:
+    """Validate files against a remote Jenkins server."""
+    linter = JenkinsfileLinter(
+        jenkins_url=args.jenkins_url,
+        username=args.username,
+        token=args.token,
+    )
+    _validate_files(linter, args)
+
+
+def _run_local_validation(args: argparse.Namespace) -> None:
+    """Validate files against a local Docker-based Jenkins server."""
+    try:
+        local = LocalJenkins()
+        url = local.ensure_running()
+        if args.verbose:
+            print(f"✓ Local Jenkins ready at {url}")
+        linter = JenkinsfileLinter(jenkins_url=url)
+    except RuntimeError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    _validate_files(linter, args)
+
+    # In --local mode, the container stays running so subsequent
+    # invocations are fast.  Use ``jenkinsfilelint server stop`` to
+    # shut it down explicitly.
+
+
 def main():
-    """Main entry point for the CLI."""
+    """Main entry point for jenkinsfilelint.
+
+    Dispatches ``server`` subcommands (start|stop|status|restart) or runs the
+    linting CLI (with optional ``--local`` mode).
+    """
+    if len(sys.argv) > 1 and sys.argv[1] == "server":
+        handle_server_command(sys.argv[2:])
+        return
+
     # Ensure stdout and stderr use UTF-8 encoding on Windows
     # Only wrap if not already wrapped to avoid issues in tests
     if sys.platform == "win32":
@@ -100,6 +177,13 @@ def main():
         help="Jenkins API token (can also be set via JENKINS_TOKEN env var)",
     )
     parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Validate using a local Docker-based Jenkins server (no remote Jenkins required). "
+        "The container is started automatically on first use and stays running for fast "
+        "subsequent invocations. Use 'jenkinsfilelint server stop' to shut it down.",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -125,50 +209,10 @@ def main():
 
     args = parser.parse_args()
 
-    # Create linter instance
-    linter = JenkinsfileLinter(
-        jenkins_url=args.jenkins_url,
-        username=args.username,
-        token=args.token,
-    )
-
-    # Validate all provided files
-    all_valid = True
-    printed_messages = set()  # Track messages already printed for deduplication
-
-    for jenkinsfile in args.jenkinsfile:
-        # Check if file should be included (whitelist)
-        if not should_include_file(jenkinsfile, args.include):
-            if args.verbose:
-                print(f"⊘ {jenkinsfile}: Skipped (does not match include pattern)")
-            continue
-
-        # Check if file should be skipped (blacklist)
-        if should_skip_file(jenkinsfile, args.skip):
-            if args.verbose:
-                print(f"⊘ {jenkinsfile}: Skipped (matches skip pattern)")
-            continue
-
-        if args.verbose:
-            print(f"Validating {jenkinsfile}...")
-
-        is_valid, message = linter.validate(jenkinsfile)
-
-        if is_valid:
-            # Show valid status for multiple files or when verbose
-            if args.verbose or len(args.jenkinsfile) > 1:
-                print(f"✓ {jenkinsfile}: Valid")
-            if args.verbose and message:
-                print(f"  {message}")
-        else:
-            # Deduplicate error messages (e.g., credentials errors)
-            if message not in printed_messages:
-                print(f"  {message}", file=sys.stderr)
-                printed_messages.add(message)
-            all_valid = False
-
-    # Exit with appropriate code
-    sys.exit(0 if all_valid else 1)
+    if args.local:
+        _run_local_validation(args)
+    else:
+        _run_remote_validation(args)
 
 
 if __name__ == "__main__":

--- a/jenkinsfilelint/local.py
+++ b/jenkinsfilelint/local.py
@@ -24,9 +24,9 @@ DEFAULT_IMAGE = "ghcr.io/jenkinsci/jenkinsfilelint-server:latest"
 DEFAULT_PORT = 18080
 CONTAINER_LABEL = "jenkinsfilelint-server"
 CONTAINER_NAME = "jenkinsfilelint-server"
-POLL_INTERVAL = 2           # seconds between readiness checks
-READY_TIMEOUT = 120         # max seconds to wait for Jenkins to start
-START_TIMEOUT = 30          # max seconds to wait for container create
+POLL_INTERVAL = 2  # seconds between readiness checks
+READY_TIMEOUT = 120  # max seconds to wait for Jenkins to start
+START_TIMEOUT = 30  # max seconds to wait for container create
 
 
 def _find_runtime() -> Optional[str]:
@@ -62,6 +62,7 @@ def _run(
 # ---------------------------------------------------------------------------
 # Container helpers
 # ---------------------------------------------------------------------------
+
 
 def _container_id(runtime: str, label: str = CONTAINER_LABEL) -> Optional[str]:
     """Return the container ID of the running container with *label*, or *None*."""
@@ -101,19 +102,23 @@ def _start_container(
     """
     log.info("Starting Jenkins container (%s)…", image)
     cmd = [
-        runtime, "run", "--detach",
-        "--name", name,
-        "--label", label,
-        "--publish", f"127.0.0.1:{port}:8080",
-        "--restart", "no",
+        runtime,
+        "run",
+        "--detach",
+        "--name",
+        name,
+        "--label",
+        label,
+        "--publish",
+        f"127.0.0.1:{port}:8080",
+        "--restart",
+        "no",
         image,
     ]
     try:
         result = _run(cmd, timeout=START_TIMEOUT)
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"Failed to start container:\n{exc.stderr}"
-        ) from exc
+        raise RuntimeError(f"Failed to start container:\n{exc.stderr}") from exc
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError("Timed out waiting for container to start") from exc
 
@@ -153,6 +158,7 @@ def _container_logs(runtime: str, container_id: str, tail: int = 20) -> str:
 # Readiness probe
 # ---------------------------------------------------------------------------
 
+
 def _wait_for_jenkins(url: str, timeout: int = READY_TIMEOUT) -> bool:
     """Poll *url*/login until Jenkins responds (HTTP 200) or *timeout* expires.
 
@@ -175,6 +181,7 @@ def _wait_for_jenkins(url: str, timeout: int = READY_TIMEOUT) -> bool:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 class LocalJenkins:
     """Manages a local Jenkins container for Declarative Pipeline validation.

--- a/jenkinsfilelint/local.py
+++ b/jenkinsfilelint/local.py
@@ -1,0 +1,348 @@
+"""Local Docker container lifecycle management for jenkinsfilelint.
+
+This module manages a minimal Jenkins container that runs on localhost,
+allowing ``jenkinsfilelint --local`` to validate Jenkinsfiles without
+requiring a remote Jenkins server.
+"""
+
+import os
+import time
+import logging
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+DEFAULT_IMAGE = "ghcr.io/jenkinsci/jenkinsfilelint-server:latest"
+DEFAULT_PORT = 18080
+CONTAINER_LABEL = "jenkinsfilelint-server"
+CONTAINER_NAME = "jenkinsfilelint-server"
+POLL_INTERVAL = 2           # seconds between readiness checks
+READY_TIMEOUT = 120         # max seconds to wait for Jenkins to start
+START_TIMEOUT = 30          # max seconds to wait for container create
+
+
+def _find_runtime() -> Optional[str]:
+    """Return the path to 'docker' or 'podman', or *None* if neither is found."""
+    for binary in ("docker", "podman"):
+        path = shutil.which(binary)
+        if path is not None:
+            return path
+    return None
+
+
+def _run(
+    cmd: list[str],
+    timeout: int = 30,
+    check: bool = True,
+    **kwargs,
+) -> subprocess.CompletedProcess:
+    """Run *cmd* and return the result.
+
+    Wraps :func:`subprocess.run` with sensible defaults (text mode, merged
+    stderr so error messages are visible).
+    """
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Container helpers
+# ---------------------------------------------------------------------------
+
+def _container_id(runtime: str, label: str = CONTAINER_LABEL) -> Optional[str]:
+    """Return the container ID of the running container with *label*, or *None*."""
+    try:
+        result = _run(
+            [runtime, "ps", "--filter", f"label={label}", "--format", "{{.ID}}"],
+            check=False,
+        )
+        cid = result.stdout.strip()
+        return cid if cid else None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def _container_is_running(runtime: str, container_id: str) -> bool:
+    """Check if the container with *container_id* is actually running."""
+    try:
+        result = _run(
+            [runtime, "inspect", "--format", "{{.State.Status}}", container_id],
+            check=False,
+        )
+        return result.stdout.strip() == "running"
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def _start_container(
+    runtime: str,
+    image: str,
+    port: int = DEFAULT_PORT,
+    name: str = CONTAINER_NAME,
+    label: str = CONTAINER_LABEL,
+) -> str:
+    """Start a new container and return its ID.
+
+    Raises :exc:`RuntimeError` if the container cannot be started.
+    """
+    log.info("Starting Jenkins container (%s)…", image)
+    cmd = [
+        runtime, "run", "--detach",
+        "--name", name,
+        "--label", label,
+        "--publish", f"127.0.0.1:{port}:8080",
+        "--restart", "no",
+        image,
+    ]
+    try:
+        result = _run(cmd, timeout=START_TIMEOUT)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Failed to start container:\n{exc.stderr}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("Timed out waiting for container to start") from exc
+
+    cid = result.stdout.strip()
+    if not cid:
+        raise RuntimeError("Container started but no ID was returned")
+    log.info("Container %s started", cid[:12])
+    return cid
+
+
+def _stop_container(runtime: str, container_id: str, timeout: int = 15) -> None:
+    """Stop and remove the container."""
+    log.info("Stopping container %s …", container_id[:12])
+    try:
+        _run([runtime, "stop", "--time", str(timeout), container_id], check=False)
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        _run([runtime, "rm", "--force", container_id], check=False)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _container_logs(runtime: str, container_id: str, tail: int = 20) -> str:
+    """Return the last *tail* lines of container logs."""
+    try:
+        result = _run(
+            [runtime, "logs", "--tail", str(tail), container_id],
+            check=False,
+        )
+        return result.stdout + result.stderr
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return "<unable to read logs>"
+
+
+# ---------------------------------------------------------------------------
+# Readiness probe
+# ---------------------------------------------------------------------------
+
+def _wait_for_jenkins(url: str, timeout: int = READY_TIMEOUT) -> bool:
+    """Poll *url*/login until Jenkins responds (HTTP 200) or *timeout* expires.
+
+    Returns ``True`` if Jenkins is ready, ``False`` on timeout.
+    """
+    login_url = f"{url.rstrip('/')}/login"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = urllib.request.urlopen(login_url, timeout=5)
+            if resp.status == 200:
+                log.info("Jenkins is ready at %s", url)
+                return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(POLL_INTERVAL)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+class LocalJenkins:
+    """Manages a local Jenkins container for Declarative Pipeline validation.
+
+    Typical usage::
+
+        lj = LocalJenkins()
+        url = lj.ensure_running()
+        # … validate using url …
+        lj.stop()
+    """
+
+    def __init__(
+        self,
+        image: Optional[str] = None,
+        port: Optional[int] = None,
+    ):
+        self.image = image or os.environ.get(
+            "JENKINSFILELINT_SERVER_IMAGE", DEFAULT_IMAGE
+        )
+        self.port = port or DEFAULT_PORT
+        self._runtime: Optional[str] = None
+        self._container_id: Optional[str] = None
+
+    @property
+    def runtime(self) -> str:
+        """The container runtime (docker/podman), discovered on first access."""
+        if self._runtime is None:
+            r = _find_runtime()
+            if r is None:
+                raise RuntimeError(
+                    "Neither 'docker' nor 'podman' was found on your PATH. "
+                    "Install Docker Desktop or Podman to use --local mode."
+                )
+            self._runtime = r
+        return self._runtime
+
+    @property
+    def container_id(self) -> Optional[str]:
+        """The running container's ID, lazily discovered."""
+        if self._container_id is None:
+            self._container_id = _container_id(self.runtime)
+        return self._container_id
+
+    def status(self) -> dict:
+        """Return a dict describing the current container state.
+
+        Keys: ``running`` (bool), ``container_id`` (str or None),
+        ``url`` (str or None), ``port`` (int).
+        """
+        cid = self.container_id
+        if cid is not None and _container_is_running(self.runtime, cid):
+            return {
+                "running": True,
+                "container_id": cid,
+                "port": self.port,
+                "url": f"http://127.0.0.1:{self.port}",
+            }
+        return {
+            "running": False,
+            "container_id": None,
+            "port": self.port,
+            "url": None,
+        }
+
+    def ensure_running(self) -> str:
+        """Ensure the local Jenkins container is running and ready.
+
+        If no container with the expected label exists, a new one is started.
+        Blocks until Jenkins responds on its HTTP port.
+
+        Returns:
+            The base URL of the local Jenkins (e.g. ``http://127.0.0.1:18080``).
+
+        Raises:
+            RuntimeError: If the runtime cannot be found, the container cannot
+                be started, or Jenkins does not become ready within the timeout.
+        """
+        # 1. Check for an existing container.
+        cid = self.container_id
+        if cid is not None and _container_is_running(self.runtime, cid):
+            log.info("Reusing existing container %s", cid[:12])
+        else:
+            # 2. Start a new container.
+            cid = _start_container(
+                self.runtime,
+                self.image,
+                port=self.port,
+            )
+            self._container_id = cid
+
+        # 3. Wait for Jenkins to be ready.
+        url = f"http://127.0.0.1:{self.port}"
+        if not _wait_for_jenkins(url):
+            logs = _container_logs(self.runtime, cid)
+            # Stop the failed container so the user can retry cleanly
+            _stop_container(self.runtime, cid, timeout=5)
+            self._container_id = None
+            raise RuntimeError(
+                f"Jenkins did not become ready within {READY_TIMEOUT}s.\n"
+                f"Container logs (last 20 lines):\n{logs}"
+            )
+
+        return url
+
+    def stop(self) -> None:
+        """Stop and remove the local Jenkins container (if running)."""
+        cid = self.container_id
+        if cid is not None:
+            _stop_container(self.runtime, cid)
+            self._container_id = None
+            print("✓ Jenkins container stopped", file=sys.stderr)
+        else:
+            print("ℹ No Jenkins container is running", file=sys.stderr)
+
+    def restart(self) -> str:
+        """Restart the container and wait for readiness.
+
+        Returns:
+            The base URL of the local Jenkins.
+        """
+        self.stop()
+        # Clear the cached container ID so a fresh one is discovered
+        self._container_id = None
+        return self.ensure_running()
+
+
+def handle_server_command(argv: list[str]) -> None:
+    """Handle the ``jenkinsfilelint server <action>`` subcommand."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="jenkinsfilelint server",
+        description="Manage the local Jenkins validation server container.",
+    )
+    parser.add_argument(
+        "action",
+        choices=["start", "stop", "status", "restart"],
+        help="Action to perform on the local server",
+    )
+    args = parser.parse_args(argv)
+
+    local = LocalJenkins()
+
+    try:
+        if args.action == "start":
+            url = local.ensure_running()
+            print(f"✓ Jenkins is ready at {url}", file=sys.stderr)
+
+        elif args.action == "stop":
+            local.stop()
+
+        elif args.action == "status":
+            state = local.status()
+            if state["running"]:
+                print(
+                    f"✓ Jenkins is running\n"
+                    f"  Container: {state['container_id'][:12]}\n"
+                    f"  URL:       {state['url']}",
+                    file=sys.stderr,
+                )
+            else:
+                print("ℹ Jenkins is not running", file=sys.stderr)
+
+        elif args.action == "restart":
+            url = local.restart()
+            print(f"✓ Jenkins restarted and ready at {url}", file=sys.stderr)
+
+    except RuntimeError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -665,6 +665,139 @@ class TestCLIIncludeOption:
             os.rmdir(groovy_dir)
 
 
+class TestCLILocalMode:
+    """Test the --local flag."""
+
+    def test_local_mode_validates_file(self):
+        """Test that --local starts a container and validates files."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with (
+                patch(
+                    "sys.argv", ["jenkinsfilelint", "--local", "--verbose", temp_path]
+                ),
+                patch("jenkinsfilelint.cli.LocalJenkins") as mock_local_cls,
+                patch("jenkinsfilelint.linter.requests.post") as mock_post,
+            ):
+                mock_instance = Mock()
+                mock_instance.ensure_running.return_value = "http://127.0.0.1:18080"
+                mock_local_cls.return_value = mock_instance
+
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = {"status": "ok"}
+                mock_response.raise_for_status = Mock()
+                mock_post.return_value = mock_response
+
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
+
+            # Verify container was started
+            mock_instance.ensure_running.assert_called_once()
+            # Verify validation against local URL
+            mock_post.assert_called_once()
+            call_url = mock_post.call_args[0][0]
+            assert "127.0.0.1" in call_url
+        finally:
+            os.unlink(temp_path)
+
+    def test_local_mode_fails_on_runtime_error(self):
+        """Test that --local exits with code 1 when container setup fails."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with (
+                patch("sys.argv", ["jenkinsfilelint", "--local", temp_path]),
+                patch("jenkinsfilelint.cli.LocalJenkins") as mock_local_cls,
+            ):
+                mock_instance = Mock()
+                mock_instance.ensure_running.side_effect = RuntimeError(
+                    "Docker not found"
+                )
+                mock_local_cls.return_value = mock_instance
+
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 1
+        finally:
+            os.unlink(temp_path)
+
+    def test_local_mode_verbose_output(self, capsys):
+        """Test that --local with --verbose prints the local URL."""
+        f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".groovy")
+        f.write("pipeline { agent any }")
+        f.flush()
+        f.close()
+        temp_path = f.name
+
+        try:
+            with (
+                patch(
+                    "sys.argv", ["jenkinsfilelint", "--local", "--verbose", temp_path]
+                ),
+                patch("jenkinsfilelint.cli.LocalJenkins") as mock_local_cls,
+                patch("jenkinsfilelint.linter.requests.post") as mock_post,
+            ):
+                mock_instance = Mock()
+                mock_instance.ensure_running.return_value = "http://127.0.0.1:18080"
+                mock_local_cls.return_value = mock_instance
+
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = {"status": "ok"}
+                mock_response.raise_for_status = Mock()
+                mock_post.return_value = mock_response
+
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
+
+            captured = capsys.readouterr()
+            assert "http://127.0.0.1:18080" in captured.out
+            assert "Jenkinsfile successfully validated" in captured.out
+        finally:
+            os.unlink(temp_path)
+
+
+class TestMainServerDispatch:
+    """Test the server subcommand dispatch in main()."""
+
+    @patch("jenkinsfilelint.cli.handle_server_command")
+    def test_server_subcommand_dispatches(self, mock_handle):
+        """'server' as first arg should dispatch to handle_server_command."""
+        with patch("sys.argv", ["jenkinsfilelint", "server", "stop"]):
+            main()
+
+        mock_handle.assert_called_once_with(["stop"])
+
+    def test_regular_args_runs_linter(self):
+        """Non-server args should run the linter (server dispatch)."""
+        with patch("sys.argv", ["jenkinsfilelint", "--jenkins-url", "http://jenkins.example.com", "Jenkinsfile"]):
+            # main() will parse args and try to validate
+            # the file doesn't exist → SystemExit 1
+            with pytest.raises(SystemExit) as exc:
+                main()
+            assert exc.value.code == 1
+
+    def test_local_flag_not_dispatched_as_server(self):
+        """--local should not be treated as a server subcommand."""
+        with patch("sys.argv", ["jenkinsfilelint", "--local", "Jenkinsfile"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+            # Should exit 1 (no Docker), not 2 (bad server action)
+            assert exc.value.code == 1
+
+
 class TestWindowsUTF8Encoding:
     """Test UTF-8 encoding setup on Windows."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -782,7 +782,15 @@ class TestMainServerDispatch:
 
     def test_regular_args_runs_linter(self):
         """Non-server args should run the linter (server dispatch)."""
-        with patch("sys.argv", ["jenkinsfilelint", "--jenkins-url", "http://jenkins.example.com", "Jenkinsfile"]):
+        with patch(
+            "sys.argv",
+            [
+                "jenkinsfilelint",
+                "--jenkins-url",
+                "http://jenkins.example.com",
+                "Jenkinsfile",
+            ],
+        ):
             # main() will parse args and try to validate
             # the file doesn't exist → SystemExit 1
             with pytest.raises(SystemExit) as exc:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Tests for the local Docker lifecycle manager."""
+
+import os
+import json
+import subprocess
+import sys
+from unittest.mock import patch, Mock, call, PropertyMock
+
+import pytest
+
+from jenkinsfilelint.local import (
+    LocalJenkins,
+    handle_server_command,
+    _find_runtime,
+    _container_id,
+    _container_is_running,
+    _start_container,
+    _stop_container,
+    _wait_for_jenkins,
+    CONTAINER_LABEL,
+    CONTAINER_NAME,
+    DEFAULT_PORT,
+    READY_TIMEOUT,
+)
+
+
+# ---------------------------------------------------------------------------
+# _find_runtime
+# ---------------------------------------------------------------------------
+
+
+class TestFindRuntime:
+    """Test container runtime discovery."""
+
+    @patch("jenkinsfilelint.local.shutil.which")
+    def test_finds_docker(self, mock_which):
+        """Should return 'docker' when it's on PATH."""
+        mock_which.side_effect = lambda x: f"/usr/bin/{x}" if x == "docker" else None
+        assert _find_runtime() == "/usr/bin/docker"
+
+    @patch("jenkinsfilelint.local.shutil.which")
+    def test_falls_back_to_podman(self, mock_which):
+        """Should return 'podman' when docker is not on PATH."""
+        mock_which.side_effect = lambda x: "/usr/bin/podman" if x == "podman" else None
+        assert _find_runtime() == "/usr/bin/podman"
+
+    @patch("jenkinsfilelint.local.shutil.which")
+    def test_returns_none_when_neither_found(self, mock_which):
+        """Should return None when neither docker nor podman is found."""
+        mock_which.return_value = None
+        assert _find_runtime() is None
+
+
+# ---------------------------------------------------------------------------
+# _container_id
+# ---------------------------------------------------------------------------
+
+
+class TestContainerID:
+    """Test container ID lookup."""
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_id_when_running(self, mock_run):
+        """Should return the container ID when a container is running."""
+        mock_result = Mock()
+        mock_result.stdout = "abc123\n"
+        mock_run.return_value = mock_result
+
+        result = _container_id("docker", label="test-label")
+        assert result == "abc123"
+        mock_run.assert_called_once_with(
+            ["docker", "ps", "--filter", "label=test-label", "--format", "{{.ID}}"],
+            check=False,
+        )
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_none_when_no_container(self, mock_run):
+        """Should return None when no container is running."""
+        mock_result = Mock()
+        mock_result.stdout = "\n"
+        mock_run.return_value = mock_result
+
+        result = _container_id("docker")
+        assert result is None
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_none_on_error(self, mock_run):
+        """Should return None when the docker command fails."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=5)
+
+        result = _container_id("docker")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _container_is_running
+# ---------------------------------------------------------------------------
+
+
+class TestContainerIsRunning:
+    """Test container running state check."""
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_true_when_running(self, mock_run):
+        """Should return True when container status is 'running'."""
+        mock_result = Mock()
+        mock_result.stdout = "running\n"
+        mock_run.return_value = mock_result
+
+        assert _container_is_running("docker", "abc123") is True
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_false_when_not_running(self, mock_run):
+        """Should return False when container status is not 'running'."""
+        mock_result = Mock()
+        mock_result.stdout = "exited\n"
+        mock_run.return_value = mock_result
+
+        assert _container_is_running("docker", "abc123") is False
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_false_on_error(self, mock_run):
+        """Should return False when the docker command fails."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=5)
+
+        assert _container_is_running("docker", "abc123") is False
+
+
+# ---------------------------------------------------------------------------
+# _start_container
+# ---------------------------------------------------------------------------
+
+
+class TestStartContainer:
+    """Test container startup."""
+
+    @patch("jenkinsfilelint.local._run")
+    def test_starts_container_and_returns_id(self, mock_run):
+        """Should start a container and return its ID."""
+        mock_result = Mock()
+        mock_result.stdout = "container-id-123\n"
+        mock_run.return_value = mock_result
+
+        cid = _start_container("docker", "my-image:latest", port=18080)
+        assert cid == "container-id-123"
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["docker", "run", "--detach"]
+        assert "--name" in cmd
+        assert CONTAINER_NAME in cmd
+        assert "127.0.0.1:18080:8080" in " ".join(cmd)
+        assert "my-image:latest" in cmd
+
+    @patch("jenkinsfilelint.local._run")
+    def test_raises_runtime_error_on_failure(self, mock_run):
+        """Should raise RuntimeError when container fails to start."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, cmd="docker", stderr="port already in use"
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to start container"):
+            _start_container("docker", "my-image")
+
+    @patch("jenkinsfilelint.local._run")
+    def test_raises_runtime_error_when_no_id_returned(self, mock_run):
+        """Should raise RuntimeError when no container ID is returned."""
+        mock_result = Mock()
+        mock_result.stdout = "\n"
+        mock_run.return_value = mock_result
+
+        with pytest.raises(RuntimeError, match="no ID was returned"):
+            _start_container("docker", "my-image")
+
+
+# ---------------------------------------------------------------------------
+# _stop_container
+# ---------------------------------------------------------------------------
+
+
+class TestStopContainer:
+    """Test container shutdown."""
+
+    @patch("jenkinsfilelint.local._run")
+    def test_stops_and_removes_container(self, mock_run):
+        """Should stop and remove the container."""
+        _stop_container("docker", "abc123", timeout=10)
+        assert mock_run.call_count == 2
+        # First call: stop
+        stop_args = mock_run.call_args_list[0][0][0]
+        assert stop_args[:3] == ["docker", "stop", "--time"]
+        assert "10" in stop_args
+        # Second call: rm
+        rm_args = mock_run.call_args_list[1][0][0]
+        assert rm_args[:3] == ["docker", "rm", "--force"]
+
+    @patch("jenkinsfilelint.local._run")
+    def test_does_not_raise_on_timeout(self, mock_run):
+        """Should not raise when stop times out."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=5)
+
+        # Should not raise
+        _stop_container("docker", "abc123")
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_jenkins
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForJenkins:
+    """Test Jenkins readiness probe."""
+
+    @patch("jenkinsfilelint.local.urllib.request.urlopen")
+    def test_returns_true_when_ready(self, mock_urlopen):
+        """Should return True when Jenkins responds with HTTP 200."""
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_urlopen.return_value = mock_response
+
+        assert _wait_for_jenkins("http://127.0.0.1:18080", timeout=10) is True
+        mock_urlopen.assert_called_with("http://127.0.0.1:18080/login", timeout=5)
+
+    @patch("jenkinsfilelint.local.urllib.request.urlopen")
+    def test_returns_false_on_timeout(self, mock_urlopen):
+        """Should return False when Jenkins does not become ready."""
+        mock_urlopen.side_effect = ConnectionError("Connection refused")
+
+        assert _wait_for_jenkins("http://127.0.0.1:18080", timeout=0.1) is False
+
+    @patch("jenkinsfilelint.local.urllib.request.urlopen")
+    def test_retries_on_connection_errors(self, mock_urlopen):
+        """Should retry when connection is refused."""
+        # First two calls fail, third succeeds
+        mock_urlopen.side_effect = [
+            ConnectionError("Connection refused"),
+            OSError("Connection reset"),
+            Mock(status=200),
+        ]
+
+        result = _wait_for_jenkins("http://127.0.0.1:18080", timeout=10)
+        assert result is True
+        assert mock_urlopen.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# LocalJenkins public API
+# ---------------------------------------------------------------------------
+
+
+class TestLocalJenkins:
+    """Test the LocalJenkins class."""
+
+    def test_default_image_from_constant(self):
+        """Should use the default image when none is specified."""
+        lj = LocalJenkins()
+        assert "ghcr.io/jenkinsci/jenkinsfilelint-server" in lj.image
+        assert lj.port == DEFAULT_PORT
+
+    def test_custom_image_and_port(self):
+        """Should accept custom image and port."""
+        lj = LocalJenkins(image="my-jenkins:latest", port=9999)
+        assert lj.image == "my-jenkins:latest"
+        assert lj.port == 9999
+
+    @patch.dict(os.environ, {"JENKINSFILELINT_SERVER_IMAGE": "custom-image:v1"})
+    def test_image_from_env_var(self):
+        """Should read image from environment variable."""
+        lj = LocalJenkins()
+        assert lj.image == "custom-image:v1"
+
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_runtime_discovery(self, mock_find):
+        """Should discover the runtime."""
+        mock_find.return_value = "/usr/bin/docker"
+        lj = LocalJenkins()
+        assert lj.runtime == "/usr/bin/docker"
+
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_runtime_not_found_raises(self, mock_find):
+        """Should raise RuntimeError when no runtime is found."""
+        mock_find.return_value = None
+        lj = LocalJenkins()
+        with pytest.raises(RuntimeError, match="Neither 'docker' nor 'podman'"):
+            _ = lj.runtime
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_status_running(self, mock_find, mock_cid):
+        """Status should indicate running when container is up."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = "abc123"
+
+        with patch("jenkinsfilelint.local._container_is_running") as mock_ir:
+            mock_ir.return_value = True
+            lj = LocalJenkins()
+            state = lj.status()
+
+        assert state["running"] is True
+        assert state["container_id"] == "abc123"
+        assert state["port"] == DEFAULT_PORT
+        assert state["url"] == f"http://127.0.0.1:{DEFAULT_PORT}"
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_status_not_running(self, mock_find, mock_cid):
+        """Status should indicate not running when container is absent."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = None
+
+        lj = LocalJenkins()
+        state = lj.status()
+
+        assert state["running"] is False
+        assert state["container_id"] is None
+        assert state["url"] is None
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_ensure_running_reuses_existing(self, mock_find, mock_cid):
+        """Should reuse existing running container."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = "abc123"
+
+        with (
+            patch("jenkinsfilelint.local._container_is_running") as mock_ir,
+            patch("jenkinsfilelint.local._wait_for_jenkins") as mock_wait,
+        ):
+            mock_ir.return_value = True
+            mock_wait.return_value = True
+
+            lj = LocalJenkins()
+            url = lj.ensure_running()
+
+        assert url == f"http://127.0.0.1:{DEFAULT_PORT}"
+        # Should NOT try to start a new container
+        # (no _start_container call)
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_ensure_running_starts_new(self, mock_find, mock_cid):
+        """Should start a new container when none is running."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = None  # No existing container
+
+        with (
+            patch("jenkinsfilelint.local._start_container") as mock_start,
+            patch("jenkinsfilelint.local._wait_for_jenkins") as mock_wait,
+        ):
+            mock_start.return_value = "new-container-id"
+            mock_wait.return_value = True
+
+            lj = LocalJenkins()
+            url = lj.ensure_running()
+
+        assert url == f"http://127.0.0.1:{DEFAULT_PORT}"
+        mock_start.assert_called_once()
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_ensure_running_raises_on_timeout(self, mock_find, mock_cid):
+        """Should raise RuntimeError when Jenkins does not become ready."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = None
+
+        with (
+            patch("jenkinsfilelint.local._start_container") as mock_start,
+            patch("jenkinsfilelint.local._wait_for_jenkins") as mock_wait,
+            patch("jenkinsfilelint.local._stop_container") as mock_stop,
+            patch("jenkinsfilelint.local._container_logs") as mock_logs,
+        ):
+            mock_start.return_value = "new-container-id"
+            mock_wait.return_value = False
+            mock_logs.return_value = "some logs"
+
+            lj = LocalJenkins()
+            with pytest.raises(RuntimeError, match="did not become ready"):
+                lj.ensure_running()
+
+            # Should clean up the failed container
+            mock_stop.assert_called_once()
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_stop_removes_container(self, mock_find, mock_cid):
+        """Should stop and remove the container."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = "abc123"
+
+        with patch("jenkinsfilelint.local._stop_container") as mock_stop:
+            lj = LocalJenkins()
+            lj.stop()
+
+        mock_stop.assert_called_once()
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_stop_when_not_running(self, mock_find, mock_cid):
+        """Should not error when stopping a non-running container."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = None
+
+        lj = LocalJenkins()
+        # Should not raise
+        lj.stop()
+
+    @patch("jenkinsfilelint.local._container_id")
+    @patch("jenkinsfilelint.local._find_runtime")
+    def test_restart_stops_then_starts(self, mock_find, mock_cid):
+        """Restart should stop and re-start the container."""
+        mock_find.return_value = "/usr/bin/docker"
+        mock_cid.return_value = "abc123"
+
+        with (
+            patch.object(LocalJenkins, "stop") as mock_stop,
+            patch.object(LocalJenkins, "ensure_running") as mock_ensure,
+        ):
+            mock_ensure.return_value = "http://127.0.0.1:18080"
+
+            lj = LocalJenkins()
+            url = lj.restart()
+
+        mock_stop.assert_called_once()
+        mock_ensure.assert_called_once()
+        assert url == "http://127.0.0.1:18080"
+
+
+# ---------------------------------------------------------------------------
+# handle_server_command
+# ---------------------------------------------------------------------------
+
+
+class TestHandleServerCommand:
+    """Test the server subcommand handler."""
+
+    @patch("jenkinsfilelint.local.LocalJenkins")
+    def test_server_start(self, mock_local_cls):
+        """'server start' should call ensure_running."""
+        mock_instance = Mock()
+        mock_instance.ensure_running.return_value = "http://127.0.0.1:18080"
+        mock_local_cls.return_value = mock_instance
+
+        with patch.object(sys, "stderr"):
+            handle_server_command(["start"])
+
+        mock_instance.ensure_running.assert_called_once()
+
+    @patch("jenkinsfilelint.local.LocalJenkins")
+    def test_server_stop(self, mock_local_cls):
+        """'server stop' should call stop."""
+        mock_instance = Mock()
+        mock_local_cls.return_value = mock_instance
+
+        with patch.object(sys, "stderr"):
+            handle_server_command(["stop"])
+
+        mock_instance.stop.assert_called_once()
+
+    @patch("jenkinsfilelint.local.LocalJenkins")
+    def test_server_status(self, mock_local_cls):
+        """'server status' should call status."""
+        mock_instance = Mock()
+        mock_instance.status.return_value = {
+            "running": True,
+            "container_id": "abc123",
+            "port": 18080,
+            "url": "http://127.0.0.1:18080",
+        }
+        mock_local_cls.return_value = mock_instance
+
+        with patch.object(sys, "stderr"):
+            handle_server_command(["status"])
+
+        mock_instance.status.assert_called_once()
+
+    @patch("jenkinsfilelint.local.LocalJenkins")
+    def test_server_restart(self, mock_local_cls):
+        """'server restart' should call restart."""
+        mock_instance = Mock()
+        mock_instance.restart.return_value = "http://127.0.0.1:18080"
+        mock_local_cls.return_value = mock_instance
+
+        with patch.object(sys, "stderr"):
+            handle_server_command(["restart"])
+
+        mock_instance.restart.assert_called_once()
+
+    @patch("jenkinsfilelint.local.LocalJenkins")
+    def test_server_start_raises_on_runtime_error(self, mock_local_cls):
+        """Should exit with code 1 on RuntimeError."""
+        mock_instance = Mock()
+        mock_instance.ensure_running.side_effect = RuntimeError("something broke")
+        mock_local_cls.return_value = mock_instance
+
+        with pytest.raises(SystemExit) as exc:
+            handle_server_command(["start"])
+
+        assert exc.value.code == 1
+
+    def test_server_invalid_action(self):
+        """Should exit with code 2 on invalid action."""
+        with pytest.raises(SystemExit) as exc:
+            handle_server_command(["fly"])
+
+        # argparse error → exit code 2
+        assert exc.value.code == 2

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -16,6 +16,7 @@ from jenkinsfilelint.local import (
     _container_is_running,
     _start_container,
     _stop_container,
+    _container_logs,
     _wait_for_jenkins,
     CONTAINER_NAME,
     DEFAULT_PORT,
@@ -161,6 +162,14 @@ class TestStartContainer:
             _start_container("docker", "my-image")
 
     @patch("jenkinsfilelint.local._run")
+    def test_raises_runtime_error_on_timeout(self, mock_run):
+        """Should raise RuntimeError when container start times out."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=30)
+
+        with pytest.raises(RuntimeError, match="Timed out waiting for container"):
+            _start_container("docker", "my-image")
+
+    @patch("jenkinsfilelint.local._run")
     def test_raises_runtime_error_when_no_id_returned(self, mock_run):
         """Should raise RuntimeError when no container ID is returned."""
         mock_result = Mock()
@@ -199,6 +208,46 @@ class TestStopContainer:
 
         # Should not raise
         _stop_container("docker", "abc123")
+
+
+# ---------------------------------------------------------------------------
+# _container_logs
+# ---------------------------------------------------------------------------
+
+
+class TestContainerLogs:
+    """Test container log retrieval."""
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_stdout_plus_stderr(self, mock_run):
+        """Should return combined stdout and stderr."""
+        mock_result = Mock()
+        mock_result.stdout = "line1\nline2\n"
+        mock_result.stderr = "warn: something\n"
+        mock_run.return_value = mock_result
+
+        logs = _container_logs("docker", "abc123", tail=10)
+        assert logs == "line1\nline2\nwarn: something\n"
+        mock_run.assert_called_once_with(
+            ["docker", "logs", "--tail", "10", "abc123"],
+            check=False,
+        )
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_fallback_on_timeout(self, mock_run):
+        """Should return fallback message on TimeoutExpired."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="docker", timeout=5)
+
+        logs = _container_logs("docker", "abc123")
+        assert logs == "<unable to read logs>"
+
+    @patch("jenkinsfilelint.local._run")
+    def test_returns_fallback_on_file_not_found(self, mock_run):
+        """Should return fallback message on FileNotFoundError."""
+        mock_run.side_effect = FileNotFoundError("docker not found")
+
+        logs = _container_logs("docker", "abc123")
+        assert logs == "<unable to read logs>"
 
 
 # ---------------------------------------------------------------------------
@@ -494,6 +543,23 @@ class TestHandleServerCommand:
             handle_server_command(["start"])
 
         assert exc.value.code == 1
+
+    @patch("jenkinsfilelint.local.LocalJenkins")
+    def test_server_status_not_running(self, mock_local_cls):
+        """'server status' should show not-running message when container is down."""
+        mock_instance = Mock()
+        mock_instance.status.return_value = {
+            "running": False,
+            "container_id": None,
+            "port": 18080,
+            "url": None,
+        }
+        mock_local_cls.return_value = mock_instance
+
+        with patch.object(sys, "stderr"):
+            handle_server_command(["status"])
+
+        mock_instance.status.assert_called_once()
 
     def test_server_invalid_action(self):
         """Should exit with code 2 on invalid action."""

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -2,10 +2,9 @@
 """Tests for the local Docker lifecycle manager."""
 
 import os
-import json
 import subprocess
 import sys
-from unittest.mock import patch, Mock, call, PropertyMock
+from unittest.mock import patch, Mock
 
 import pytest
 
@@ -18,10 +17,8 @@ from jenkinsfilelint.local import (
     _start_container,
     _stop_container,
     _wait_for_jenkins,
-    CONTAINER_LABEL,
     CONTAINER_NAME,
     DEFAULT_PORT,
-    READY_TIMEOUT,
 )
 
 


### PR DESCRIPTION
Closes #35 

- Introduced a minimal Jenkins Docker image for local Declarative Pipeline validation.
- Added configuration-as-code (JCasC) for unsecured Jenkins setup.
- Implemented local validation mode in the CLI to validate Jenkinsfiles against a local Jenkins server.
- Created lifecycle management for the local Jenkins container, including start, stop, and status commands.
- Enhanced CLI to support a `--local` flag for local validation.
- Added comprehensive tests for local mode functionality and Docker container management.

### Testing done

```bash
jenkinsfilelint --local tests/Jenkinsfile
(.venv) sxp@Mac ~/R/j/jenkinsfilelint (feature/standalone-using-docker)> jenkinsfilelint --local tests/Jenkinsfile.fail 
  Errors encountered validating Jenkinsfile:
WorkflowScript: 2: Not a valid section definition: "agent". Some extra configuration is required. @ line 2, column 5.
       agent
       ^

WorkflowScript: 1: Missing required section "agent" @ line 1, column 1.
   pipeline {
   ^
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
