### PR TITLE
chore: add v prefix to release title name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 # Extends the shared Jenkins Release Drafter configuration
 # but overrides versioning to use full semver (x.y.z) instead of (x.y).
 _extends: github:jenkinsci/.github:/.github/release-drafter.yml
-name-template: $NEXT_PATCH_VERSION
+name-template: v$NEXT_PATCH_VERSION
 tag-template: $NEXT_PATCH_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
 template: |


### PR DESCRIPTION
Change `name-template` from `$NEXT_PATCH_VERSION` to `v$NEXT_PATCH_VERSION` so release titles display as `v1.4.2` instead of `1.4.2`.

The git tag (`tag-template`) stays unchanged at `$NEXT_PATCH_VERSION` (e.g., `1.4.2`).