### PR TITLE
chore: use RESOLVED_VERSION so release-drafter respects PR labels

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,11 +1,11 @@
 # Extends the shared Jenkins Release Drafter configuration
 # but overrides versioning to use full semver (x.y.z) instead of (x.y).
 _extends: github:jenkinsci/.github:/.github/release-drafter.yml
-name-template: v$NEXT_PATCH_VERSION
-tag-template: $NEXT_PATCH_VERSION
+name-template: v$RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
 template: |
   <!-- Optional: add a release summary here -->
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION


### PR DESCRIPTION
### Problem

Release-drafter was configured with `$NEXT_PATCH_VERSION` for name-template and tag-template, which **always bumps patch** regardless of PR labels. Even after labeling a PR as `minor`, the draft release still shows `v1.4.2` instead of `v1.5.0`.

### Fix

Replace all `$NEXT_PATCH_VERSION` references with `$RESOLVED_VERSION`, which automatically selects the bump level based on merged PR labels:

| Label | Bump | Example |
|-------|------|---------|
| `major` | Major | 1.4.1 → 2.0.0 |
| `minor` | Minor | 1.4.1 → 1.5.0 |
| `patch` or none | Patch | 1.4.1 → 1.4.2 |

### Changes

- `name-template`: `v$NEXT_PATCH_VERSION` → `v$RESOLVED_VERSION`
- `tag-template`: `$NEXT_PATCH_VERSION` → `$RESOLVED_VERSION`
- Changelog comparison URL: `...$NEXT_PATCH_VERSION` → `...$RESOLVED_VERSION`