### PR TITLE
chore: add version-resolver entries and PR auto-labeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,148 +1,127 @@
 # Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
-#
-# NOTE: We define everything locally instead of using _extends from the shared
-# jenkinsci/.github config because we need to add version-resolver entries to
-# the categories list. Release-drafter (up to v7.5.1) does shallow merge with
-# _extends, so defining categories locally would replace (not extend) inherited
-# categories anyway.
-#
-# Once release-drafter v7.6.0+ is released (PR #1642, merged 2026-07-11), we
-# can switch back to _extends with merge strategy:
-#
-#   _extends:
-#     from: github:jenkinsci/.github:/.github/release-drafter.yml
-#     strategy:
-#       categories: append
-#   categories:
-#     - type: version-resolver
-#       semver-increment: major
-#       when:
-#         labels:
-#           - major
-#     - type: version-resolver
-#       semver-increment: minor
-#       when:
-#         labels:
-#           - minor
 ---
-name-template: v$RESOLVED_VERSION
-tag-template: $RESOLVED_VERSION
-version-template: $MAJOR.$MINOR.$PATCH
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 
-# Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
   - title: 💥 Breaking changes
     labels:
       - breaking
-  - title: 🚨 Removed
+  - title: 🚀 Features
     labels:
-      - removed
-  - title: 🎉 Major features and improvements
-    labels:
-      - major-enhancement
-      - major-rfe
-  - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
-  - title: ⚠️ Deprecated
-    labels:
-      - deprecated
-  - title: 🚀 New features and improvements
-    labels:
-      - enhancement
       - feature
-      - rfe
+      - enhancement
   - title: 🐛 Bug fixes
     labels:
       - bug
-      - fix
       - bugfix
+      - fix
       - regression
-      - regression-fix
-  - title: 🌐 Localization and translation
-    labels:
-      - localization
-  - title: 👷 Changes for plugin developers
-    labels:
-      - developer
-  - title: 📝 Documentation updates
+  - title: 📝 Documentation
     labels:
       - documentation
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
   - title: 👻 Maintenance
     labels:
       - chore
       - internal
       - maintenance
-  - title: 🚦 Tests
-    labels:
-      - test
-      - tests
-  - title: ✍ Other changes
-  # Default label used by Dependabot
-  - title: 📦 Dependency updates
+  - title: 📦 Dependencies
     labels:
       - dependencies
     collapse-after: 15
-
-  # ---------------------------------------------------------------------------
-  # Version-resolver entries – map PR labels to semver increments.
-  # Without these, $RESOLVED_VERSION defaults to always bumping patch.
-  # ---------------------------------------------------------------------------
-  - type: version-resolver
-    semver-increment: major
-    when:
-      labels:
-        - major
-  - type: version-resolver
-    semver-increment: minor
-    when:
-      labels:
-        - minor
+  - title: 🗑 Removed
+    labels:
+      - removed
+      - deprecated
+  - title: ✍ Other changes
 
 exclude-labels:
-  - reverted
   - no-changelog
   - skip-changelog
   - invalid
+  - duplicate
+  - question
+  - wontfix
+
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
 
 template: |
-  <!-- Optional: add a release summary here -->
+  ## What's Changed
+
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
-
-replacers:
-  # Copied from jenkinsci/.github/.github/release-drafter.yml
-  - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
-    replace: '[JENKINS-$1](https://issue-redirect.jenkins.io/issue/$1) - '
-  - search: '/\[*HELPDESK-(\d+)\]*\s*-*\s*/g'
-    replace: '[HELPDESK-$1](https://github.com/jenkins-infra/helpdesk/issues/$1) - '
-  - search: '/\[*SECURITY-(\d+)\]*\s*-*\s*/g'
-    replace: '[SECURITY-$1](https://jenkins.io/security/advisories/) - '
-  - search: '/\[*JEP-(\d+)\]*\s*-*\s*/g'
-    replace: '[JEP-$1](https://github.com/jenkinsci/jep/tree/master/jep/$1) - '
-  - search: '/CVE-(\d{4})-(\d+)/g'
-    replace: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2'
-  - search: 'JFR'
-    replace: 'Jenkinsfile Runner'
-  - search: 'CWP'
-    replace: 'Custom WAR Packager'
-  - search: '@dependabot-preview'
-    replace: '@dependabot'
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
 autolabeler:
-  - label: 'documentation'
+  # ── Title-based (conventional commit prefix) ──────────────
+  - label: enhancement
+    title:
+      - /^feat(\(.*\))?:.*/
+      - /^feature(\(.*\))?:.*/
+      - /^perf(\(.*\))?:.*/
+  - label: bug
+    title:
+      - /^fix(\(.*\))?:.*/
+      - /^bugfix(\(.*\))?:.*/
+  - label: documentation
+    title:
+      - /^docs(\(.*\))?:.*/
+  - label: chore
+    title:
+      - /^chore(\(.*\))?:.*/
+      - /^refactor(\(.*\))?:.*/
+      - /^style(\(.*\))?:.*/
+      - /^build(\(.*\))?:.*/
+      - /^revert(\(.*\))?:.*/
+  - label: tests
+    title:
+      - /^test(\(.*\))?:.*/
+      - /^tests(\(.*\))?:.*/
+
+  # ── Branch-based ──────────────────────────────────────────
+  - label: enhancement
+    branch:
+      - /^feature\/.+/
+      - /^feat\/.+/
+  - label: bug
+    branch:
+      - /^fix\/.+/
+      - /^bugfix\/.+/
+  - label: chore
+    branch:
+      - /^chore\/.+/
+  - label: tests
+    branch:
+      - /^test\/.+/
+  - label: dependencies
+    branch:
+      - /^pre-commit-ci-update-config/
+
+  # ── File-based ────────────────────────────────────────────
+  - label: documentation
     files:
       - '*.md'
-    branch:
-      - '/docs{0,1}\/.+/'
-  - label: 'bug'
-    branch:
-      - '/fix\/.+/'
-    title:
-      - '/fix/i'
-  - label: 'enhancement'
-    branch:
-      - '/feature\/.+/'
-    body:
-      - '/JENKINS-[0-9]{1,4}/'
+      - '*.rst'
+      - '*.adoc'
+  - label: tests
+    files:
+      - 'test/**'
+      - 'tests/**'
+      - '__tests__/**'
+      - '*.test.*'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,11 +1,148 @@
-# Extends the shared Jenkins Release Drafter configuration
-# but overrides versioning to use full semver (x.y.z) instead of (x.y).
-_extends: github:jenkinsci/.github:/.github/release-drafter.yml
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+#
+# NOTE: We define everything locally instead of using _extends from the shared
+# jenkinsci/.github config because we need to add version-resolver entries to
+# the categories list. Release-drafter (up to v7.5.1) does shallow merge with
+# _extends, so defining categories locally would replace (not extend) inherited
+# categories anyway.
+#
+# Once release-drafter v7.6.0+ is released (PR #1642, merged 2026-07-11), we
+# can switch back to _extends with merge strategy:
+#
+#   _extends:
+#     from: github:jenkinsci/.github:/.github/release-drafter.yml
+#     strategy:
+#       categories: append
+#   categories:
+#     - type: version-resolver
+#       semver-increment: major
+#       when:
+#         labels:
+#           - major
+#     - type: version-resolver
+#       semver-increment: minor
+#       when:
+#         labels:
+#           - minor
+---
 name-template: v$RESOLVED_VERSION
 tag-template: $RESOLVED_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
+
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: 💥 Breaking changes
+    labels:
+      - breaking
+  - title: 🚨 Removed
+    labels:
+      - removed
+  - title: 🎉 Major features and improvements
+    labels:
+      - major-enhancement
+      - major-rfe
+  - title: 🐛 Major bug fixes
+    labels:
+      - major-bug
+  - title: ⚠️ Deprecated
+    labels:
+      - deprecated
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+      - rfe
+  - title: 🐛 Bug fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+      - regression
+      - regression-fix
+  - title: 🌐 Localization and translation
+    labels:
+      - localization
+  - title: 👷 Changes for plugin developers
+    labels:
+      - developer
+  - title: 📝 Documentation updates
+    labels:
+      - documentation
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - internal
+      - maintenance
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
+  - title: ✍ Other changes
+  # Default label used by Dependabot
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
+    collapse-after: 15
+
+  # ---------------------------------------------------------------------------
+  # Version-resolver entries – map PR labels to semver increments.
+  # Without these, $RESOLVED_VERSION defaults to always bumping patch.
+  # ---------------------------------------------------------------------------
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels:
+        - major
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels:
+        - minor
+
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+
 template: |
   <!-- Optional: add a release summary here -->
   $CHANGES
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+
+replacers:
+  # Copied from jenkinsci/.github/.github/release-drafter.yml
+  - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
+    replace: '[JENKINS-$1](https://issue-redirect.jenkins.io/issue/$1) - '
+  - search: '/\[*HELPDESK-(\d+)\]*\s*-*\s*/g'
+    replace: '[HELPDESK-$1](https://github.com/jenkins-infra/helpdesk/issues/$1) - '
+  - search: '/\[*SECURITY-(\d+)\]*\s*-*\s*/g'
+    replace: '[SECURITY-$1](https://jenkins.io/security/advisories/) - '
+  - search: '/\[*JEP-(\d+)\]*\s*-*\s*/g'
+    replace: '[JEP-$1](https://github.com/jenkinsci/jep/tree/master/jep/$1) - '
+  - search: '/CVE-(\d{4})-(\d+)/g'
+    replace: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2'
+  - search: 'JFR'
+    replace: 'Jenkinsfile Runner'
+  - search: 'CWP'
+    replace: 'Custom WAR Packager'
+  - search: '@dependabot-preview'
+    replace: '@dependabot'
+
+autolabeler:
+  - label: 'documentation'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    body:
+      - '/JENKINS-[0-9]{1,4}/'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: PR Auto-labeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  auto-label:
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Uses local .github/release-drafter.yml autolabeler config by default.
+        # No config-name needed — it auto-discovers the config in this repo.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter/autolabeler@v7
+      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Uses local .github/release-drafter.yml autolabeler config by default.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,5 +18,5 @@ jobs:
 
     steps:
       - uses: release-drafter/release-drafter@v7
-        # Uses local .github/release-drafter.yml which extends the shared
-        # jenkinsci/.github config but overrides versioning to full semver (x.y.z).
+        # Uses local .github/release-drafter.yml with version-resolver
+        # entries for semver bumping based on PR labels.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         # Uses local .github/release-drafter.yml with version-resolver
         # entries for semver bumping based on PR labels.


### PR DESCRIPTION
## Summary

This PR makes two changes to improve the release workflow:

### 1. Version resolution respects PR labels

Replace the old config that used `_extends` from jenkinsci/.github with a standalone config that uses release-drafter's top-level `version-resolver` format:

```yaml
version-resolver:
  major:
    labels:
      - major
  minor:
    labels:
      - minor
  patch:
    labels:
      - patch
  default: patch
```

This means:
- PRs with `major` label → major version bump (e.g. 1.4.1 → 2.0.0)
- PRs with `minor` label → minor version bump (e.g. 1.4.1 → 1.5.0)
- No label / `patch` label → patch version bump (e.g. 1.4.1 → 1.4.2)

Previously, without version-resolver entries, `$RESOLVED_VERSION` always defaulted to patch regardless of PR labels (PR #38 with `minor` label was drafted as v1.4.2 instead of v1.5.0).

### 2. PR Auto-labeler workflow

Add `.github/workflows/labeler.yml` that runs on `pull_request` events and automatically labels PRs based on the `autolabeler` rules in `.github/release-drafter.yml`. This uses release-drafter's built-in autolabeler action with conventional commit title matching.

### Additional changes

- **autolabeler rules**: title-based (conventional commit prefixes like `feat:`, `fix:`, `docs:`, `chore:`, `test:`), branch-based (`feature/`, `fix/`, `chore/`, `test/`), and file-based (documentation extensions, test directories)
- **categories**: simplified to match the labels actually used in this repo
- **change-template**: new format `- $TITLE by @$AUTHOR in #$NUMBER`
- Removed unused replacers (JENKINS-*, CVE-*, JFR, etc.)
- Tag now includes `v` prefix for consistency with release names