### PR TITLE
chore: set org.opencontainers.image.description label in Docker metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short
             type=schedule,pattern={{date 'YYYY-MM'}}
+          labels: |
+            org.opencontainers.image.description=Minimal Jenkins image for Declarative Pipeline syntax validation
 
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0


### PR DESCRIPTION
## Problem

The Docker image on ghcr.io shows "No description provided" on the package page, even though the `Dockerfile` contains `org.opencontainers.image.description`.

## Root Cause

The CI workflow uses `docker/metadata-action` which auto-generates labels from the GitHub repository metadata — including `org.opencontainers.image.description` from the repo description field. These auto-generated labels **override** the `LABEL` instructions in the `Dockerfile` during the build.

Since the repository description on GitHub may be empty or different, the resulting image on ghcr.io lacks the proper description.

## Changes

Added an explicit `labels` configuration to the `docker/metadata-action` step in `.github/workflows/docker.yml`:

```yaml
labels: |
  org.opencontainers.image.description=Minimal Jenkins image for Declarative Pipeline syntax validation
```

This ensures the description is always set correctly on the published image, matching the existing `LABEL` in the `Dockerfile`.

## Reference

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images