### PR TITLE
chore: add OCI index annotations for multi-arch image description on ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,5 +60,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: |
+            index:org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            index:org.opencontainers.image.description=Minimal Jenkins image for Declarative Pipeline syntax validation
+            index:org.opencontainers.image.licenses=MIT
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short
             type=schedule,pattern={{date 'YYYY-MM'}}
+          labels: |
+            org.opencontainers.image.description=Minimal Jenkins image for Declarative Pipeline syntax validation
 
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0


### PR DESCRIPTION
## Problem

The Docker image on ghcr.io still shows "No description provided" even after PR #49 was merged.

## Root Cause

The image is **multi-arch** (OCI image index). For multi-arch images, `LABEL` in the Dockerfile and `labels` in docker/build-push-action only affect the **individual architecture manifests**, not the **OCI index** (manifest list).

ghcr.io reads the description from the **index-level annotations**, not from the per-architecture image config labels.

As documented:
> For multi-arch images, you can add a description to the image by adding the appropriate annotation key to the `annotations` field in the image's manifest.

## Changes

Added `annotations` input to `docker/build-push-action` with the `index:` prefix to set annotations on the OCI index:

```yaml
annotations: |
  index:org.opencontainers.image.source=https://github.com/${{ github.repository }}
  index:org.opencontainers.image.description=Minimal Jenkins image for Declarative Pipeline syntax validation
  index:org.opencontainers.image.licenses=MIT
```

This ensures the description (and source/license) appear on the package page at ghcr.io.

## Reference

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images